### PR TITLE
refactor: remove redundant tensor concatenation and slicing in forward pass

### DIFF
--- a/nunchaku/models/pulid/pulid_forward.py
+++ b/nunchaku/models/pulid/pulid_forward.py
@@ -109,8 +109,6 @@ def pulid_forward(
         controlnet_block_samples=controlnet_block_samples,
         controlnet_single_block_samples=controlnet_single_block_samples,
     )
-    hidden_states = torch.cat([encoder_hidden_states, hidden_states], dim=1)
-    hidden_states = hidden_states[:, encoder_hidden_states.shape[1] :, ...]
     hidden_states = self.norm_out(hidden_states, temb)
     output = self.proj_out(hidden_states)
 

--- a/nunchaku/models/transformers/transformer_flux.py
+++ b/nunchaku/models/transformers/transformer_flux.py
@@ -677,8 +677,6 @@ class NunchakuFluxTransformer2dModel(FluxTransformer2DModel, NunchakuModelLoader
             controlnet_block_samples=controlnet_block_samples,
             controlnet_single_block_samples=controlnet_single_block_samples,
         )
-        hidden_states = torch.cat([encoder_hidden_states, hidden_states], dim=1)
-        hidden_states = hidden_states[:, encoder_hidden_states.shape[1] :, ...]
         hidden_states = self.norm_out(hidden_states, temb)
         output = self.proj_out(hidden_states)
 


### PR DESCRIPTION
This PR removes two redundant lines of code from the model's forward pass.

These operations are unnecessary as they have no impact on the final output.

Removing them simplifies the logic and improves code readability.