### PR TITLE
chore: add tests for flux speed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ facexlib
 onnxruntime
 # ip-adapter
 timm
+diffusers>=0.33.1

--- a/tests/flux/test_flux_speed.py
+++ b/tests/flux/test_flux_speed.py
@@ -3,18 +3,18 @@
 # use quantized text encoder, see doc
 # run fp4 on 5090
 
-import time
 import logging
+import time
 
-import torch
 import pytest
-
+import torch
 from diffusers import FluxPipeline
 
 from nunchaku import NunchakuFluxTransformer2dModel, NunchakuT5EncoderModel
 from nunchaku.utils import get_precision, is_turing
 
 _LOGGER = logging.getLogger(__name__)
+
 
 @pytest.mark.skipif(is_turing(), reason="Skip tests due to using Turing GPUs")
 @pytest.mark.parametrize(
@@ -23,10 +23,16 @@ _LOGGER = logging.getLogger(__name__)
         (2, 5, 30, 3.5, True, 6.49650 if get_precision() == "int4" else 4.79388),
     ],
 )
-def test_flux_speed(warmup_times: int, test_times: int, num_inference_steps: int, guidance_scale: float, 
-                    use_qencoder: bool, expected_latency: float):
+def test_flux_speed(
+    warmup_times: int,
+    test_times: int,
+    num_inference_steps: int,
+    guidance_scale: float,
+    use_qencoder: bool,
+    expected_latency: float,
+):
     precision = get_precision()
-    
+
     pipeline_init_kwargs = {
         "transformer": NunchakuFluxTransformer2dModel.from_pretrained(
             f"mit-han-lab/nunchaku-flux.1-schnell/svdq-{precision}_r32-flux.1-schnell.safetensors", offload=False
@@ -47,23 +53,17 @@ def test_flux_speed(warmup_times: int, test_times: int, num_inference_steps: int
     dummy_prompt = "A cat holding a sign that says hello world"
 
     for _ in range(warmup_times):
-        pipeline(
-            prompt=dummy_prompt, num_inference_steps=num_inference_steps, guidance_scale=guidance_scale
-        )
+        pipeline(prompt=dummy_prompt, num_inference_steps=num_inference_steps, guidance_scale=guidance_scale)
         torch.cuda.synchronize()
     for _ in range(test_times):
         start_time = time.time()
-        pipeline(
-            prompt=dummy_prompt, num_inference_steps=num_inference_steps, guidance_scale=guidance_scale
-        )
+        pipeline(prompt=dummy_prompt, num_inference_steps=num_inference_steps, guidance_scale=guidance_scale)
         torch.cuda.synchronize()
         end_time = time.time()
         latency_list.append(end_time - start_time)
-    
-    average_latency = sum(latency_list) / len(latency_list) 
-    
+
+    average_latency = sum(latency_list) / len(latency_list)
+
     _LOGGER.debug(f"Latency: {average_latency:.5f} s")
-    
-    assert average_latency < expected_latency * 1.1, f"Expected latency < {expected_latency}, but got {average_latency}"
-    
-    
+
+    assert average_latency < expected_latency * 1.1

--- a/tests/flux/test_flux_speed.py
+++ b/tests/flux/test_flux_speed.py
@@ -11,9 +11,9 @@ from nunchaku.utils import get_precision
 _LOGGER = logging.getLogger(__name__)
 
 EXPECTED_LATENCIES = {
+    "NVIDIA GeForce RTX 3090": 16.05321,
     "NVIDIA GeForce RTX 4090": 6.49650,
     "NVIDIA GeForce RTX 5090": 4.79388,
-    "NVIDIA GeForce RTX 3090": 16.05321,
 }
 
 

--- a/tests/flux/test_flux_speed.py
+++ b/tests/flux/test_flux_speed.py
@@ -1,8 +1,3 @@
-# single case for expect latency
-# original: bf16
-# use quantized text encoder, see doc
-# run fp4 on 5090
-
 import logging
 import time
 

--- a/tests/flux/test_flux_speed.py
+++ b/tests/flux/test_flux_speed.py
@@ -1,0 +1,70 @@
+# single case for expect latency
+# original: bf16
+# use quantized text encoder, see doc
+# run fp4 on 5090
+
+import time
+
+import torch
+import pytest
+
+from diffusers import FluxPipeline
+
+from nunchaku import NunchakuFluxTransformer2dModel, NunchakuT5EncoderModel
+from nunchaku.utils import get_precision, is_turing
+
+@pytest.mark.skipif(is_turing(), reason="Skip tests due to using Turing GPUs")
+@pytest.mark.parametrize(
+    "warmup_time,test_times,num_inference_steps,guidance_scale,use_qencoder,cpu_offload,expected_latency_ms",
+    [
+        (2, 5, 30, 3.5, True, False, 100),
+    ],
+)
+def test_flux_speed(warmup_times: int, test_times: int, num_inference_steps: int, guidance_scale: float, 
+                    use_qencoder: bool, cpu_offload: bool, expected_latency_ms: float):
+    precision = get_precision()
+    pipeline_init_kwargs = {
+        "transformer": NunchakuFluxTransformer2dModel.from_pretrained(
+            f"mit-han-lab/nunchaku-flux.1-schnell/svdq-{precision}_r32-flux.1-schnell.safetensors", offload=cpu_offload
+        )
+    }
+    if use_qencoder:
+        text_encoder_2 = NunchakuT5EncoderModel.from_pretrained(
+            "mit-han-lab/nunchaku-t5/awq-int4-flux.1-t5xxl.safetensors"
+        )
+        pipeline_init_kwargs["text_encoder_2"] = text_encoder_2
+    pipeline = FluxPipeline.from_pretrained(
+        "black-forest-labs/FLUX.1-schnell", torch_dtype=torch.bfloat16, **pipeline_init_kwargs
+    )
+
+    if cpu_offload:
+        pipeline.enable_sequential_cpu_offload()
+    else:
+        pipeline = pipeline.to("cuda")
+
+    pipeline(
+        "A cat holding a sign that says hello world", 
+        width=1024, height=1024, 
+        num_inference_steps=num_inference_steps, guidance_scale=guidance_scale
+    )
+
+    latency_list = []
+    dummy_prompt = "A cat holding a sign that says hello world"
+
+    for _ in range(warmup_times):
+        pipeline(
+            prompt=dummy_prompt, num_inference_steps=num_inference_steps, guidance_scale=guidance_scale
+        )
+        torch.cuda.synchronize()
+    for _ in range(test_times):
+        start_time = time.time()
+        pipeline(
+            prompt=dummy_prompt, num_inference_steps=num_inference_steps, guidance_scale=guidance_scale
+        )
+        torch.cuda.synchronize()
+        end_time = time.time()
+        latency_list.append(end_time - start_time)
+        
+    print(f"Latency: {sum(latency_list) / len(latency_list):.5f} s")
+    
+    

--- a/tests/flux/test_flux_speed.py
+++ b/tests/flux/test_flux_speed.py
@@ -10,7 +10,7 @@ from nunchaku.utils import get_precision
 
 _LOGGER = logging.getLogger(__name__)
 
-EXPECTED_LATENCIES = {
+_EXPECTED_LATENCIES = {
     "NVIDIA GeForce RTX 3090": 16.05321,
     "NVIDIA GeForce RTX 4090": 6.49650,
     "NVIDIA GeForce RTX 5090": 4.79388,
@@ -18,12 +18,12 @@ EXPECTED_LATENCIES = {
 
 
 @pytest.mark.skipif(
-    torch.cuda.get_device_name(0) not in EXPECTED_LATENCIES, reason="Skip tests due to using unsupported GPUs"
+    torch.cuda.get_device_name(0) not in _EXPECTED_LATENCIES, reason="Skip tests due to using unsupported GPUs"
 )
 @pytest.mark.parametrize(
     "warmup_times,test_times,num_inference_steps,guidance_scale,use_qencoder,expected_latency",
     [
-        (2, 5, 30, 3.5, True, EXPECTED_LATENCIES[torch.cuda.get_device_name(0)]),
+        (2, 5, 30, 3.5, True, _EXPECTED_LATENCIES[torch.cuda.get_device_name(0)]),
     ],
 )
 def test_flux_speed(

--- a/tests/flux/test_flux_speed.py
+++ b/tests/flux/test_flux_speed.py
@@ -20,7 +20,7 @@ _LOGGER = logging.getLogger(__name__)
 @pytest.mark.parametrize(
     "warmup_times,test_times,num_inference_steps,guidance_scale,use_qencoder,expected_latency",
     [
-        (2, 5, 30, 3.5, True, 6.49650 if get_precision() == "int4" else 6.3),
+        (2, 5, 30, 3.5, True, 6.49650 if get_precision() == "int4" else 4.79388),
     ],
 )
 def test_flux_speed(warmup_times: int, test_times: int, num_inference_steps: int, guidance_scale: float, 

--- a/tests/flux/test_flux_speed.py
+++ b/tests/flux/test_flux_speed.py
@@ -6,16 +6,24 @@ import torch
 from diffusers import FluxPipeline
 
 from nunchaku import NunchakuFluxTransformer2dModel, NunchakuT5EncoderModel
-from nunchaku.utils import get_precision, is_turing
+from nunchaku.utils import get_precision
 
 _LOGGER = logging.getLogger(__name__)
 
+EXPECTED_LATENCIES = {
+    "NVIDIA GeForce RTX 4090": 6.49650,
+    "NVIDIA GeForce RTX 5090": 4.79388,
+    "NVIDIA GeForce RTX 3090": 16.05321,
+}
 
-@pytest.mark.skipif(is_turing(), reason="Skip tests due to using Turing GPUs")
+
+@pytest.mark.skipif(
+    torch.cuda.get_device_name(0) not in EXPECTED_LATENCIES, reason="Skip tests due to using unsupported GPUs"
+)
 @pytest.mark.parametrize(
     "warmup_times,test_times,num_inference_steps,guidance_scale,use_qencoder,expected_latency",
     [
-        (2, 5, 30, 3.5, True, 6.49650 if get_precision() == "int4" else 4.79388),
+        (2, 5, 30, 3.5, True, EXPECTED_LATENCIES[torch.cuda.get_device_name(0)]),
     ],
 )
 def test_flux_speed(


### PR DESCRIPTION
## Motivation

Add a new test under tests/flux for automated checking of the pipeline latency

## Modifications

1. Added diffusers in requirements.txt
2. Added a speed test for flux models and tested on both RTX 40- and 50- gpus

## Checklist

- [x] Code is formatted using Pre-Commit hooks.
- [x] Relevant unit tests are added in the [`tests`](../tests) directory following the guidance in [`Contribution Guide`](https://nunchaku.tech/docs/nunchaku/developer/contribution_guide.html).
- [ ] [Documentation](../docs/source) and example scripts in [`examples`](../examples) are updated if necessary.
- [ ] Throughput/latency benchmarks and quality evaluations are included where applicable.
- [ ] **For reviewers:** If you're only helping merge the main branch and haven't contributed code to this PR, please remove yourself as a co-author when merging.
- [ ] Please feel free to join our [Slack](https://join.slack.com/t/nunchaku/shared_invite/zt-3170agzoz-NgZzWaTrEj~n2KEV3Hpl5Q), [Discord](https://discord.gg/Wk6PnwX9Sm) or [WeChat](https://github.com/mit-han-lab/nunchaku/blob/main/assets/wechat.jpg) to discuss your PR.
