### PR TITLE
fix: ensure caching flag is set correctly

### DIFF
--- a/nunchaku/caching/diffusers_adapters/flux.py
+++ b/nunchaku/caching/diffusers_adapters/flux.py
@@ -91,7 +91,6 @@ def apply_cache_on_transformer(
                 unittest.mock.patch.object(self, "transformer_blocks", cached_transformer_blocks),
                 unittest.mock.patch.object(self, "single_transformer_blocks", dummy_single_transformer_blocks),
             ):
-                transformer._is_cached = True
                 transformer.cached_transformer_blocks = cached_transformer_blocks
                 transformer.single_transformer_blocks = dummy_single_transformer_blocks
                 return original_forward(*args, **kwargs)
@@ -99,6 +98,7 @@ def apply_cache_on_transformer(
             return original_forward(*args, **kwargs)
 
     transformer.forward = new_forward.__get__(transformer)
+    transformer._is_cached = True
     transformer.use_double_fb_cache = use_double_fb_cache
     transformer.residual_diff_threshold_multi = residual_diff_threshold_multi
     transformer.residual_diff_threshold_single = residual_diff_threshold_single


### PR DESCRIPTION
<!-- Thank you for your contribution—we truly appreciate it! To help us review your pull request efficiently, please follow the guidelines below. If anything is unclear, feel free to open the PR and ask for clarification. You can also refer to our [contribution guide](./docs/contribution_guide.md) for more details. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
The first block cache in ComfyUI nunchaku is invalid.
## Modifications

<!-- Describe the changes made in this PR. -->
Reset the cache flag to take effect.
## Checklist

- [x] Code is formatted using Pre-Commit hooks.
- [ ] Relevant unit tests are added in the [`tests`](../tests) directory following the guidance in [`Contribution Guide`](https://nunchaku.tech/docs/nunchaku/developer/contribution_guide.html).
- [ ] [Documentation](../docs/source) and example scripts in [`examples`](../examples) are updated if necessary.
- [ ] Throughput/latency benchmarks and quality evaluations are included where applicable.
- [ ] **For reviewers:** If you're only helping merge the main branch and haven't contributed code to this PR, please remove yourself as a co-author when merging.
- [ ] Please feel free to join our [Slack](https://join.slack.com/t/nunchaku/shared_invite/zt-3170agzoz-NgZzWaTrEj~n2KEV3Hpl5Q), [Discord](https://discord.gg/Wk6PnwX9Sm) or [WeChat](https://github.com/mit-han-lab/nunchaku/blob/main/assets/wechat.jpg) to discuss your PR.
