### PR TITLE
Fix: Enable Correct Batch Processing in TeaCache

### DIFF
--- a/examples/flux.1-dev-teacache-batch.py
+++ b/examples/flux.1-dev-teacache-batch.py
@@ -1,0 +1,38 @@
+import time
+
+import torch
+from diffusers.pipelines.flux.pipeline_flux import FluxPipeline
+
+from nunchaku import NunchakuFluxTransformer2dModel
+from nunchaku.caching.teacache import TeaCache
+from nunchaku.utils import get_precision
+
+precision = get_precision()  # auto-detect your precision is 'int4' or 'fp4' based on your GPU
+transformer = NunchakuFluxTransformer2dModel.from_pretrained(
+    f"nunchaku-tech/nunchaku-flux.1-dev/svdq-{precision}_r32-flux.1-dev.safetensors"
+)
+pipeline = FluxPipeline.from_pretrained(
+    "black-forest-labs/FLUX.1-dev", transformer=transformer, torch_dtype=torch.bfloat16
+).to("cuda")
+start_time = time.time()
+
+prompts = ["A cheerful woman in a pastel dress, holding a basket of colorful Easter eggs with a sign that says 'Happy Easter'",
+    "A young peace activist with a gentle smile, holding a handmade sign that says 'Peace'",
+"A friendly chef wearing a tall white hat, holding a wooden spoon with a sign that says 'Let's Cook!",
+]
+
+with TeaCache(model=transformer, num_steps=50, rel_l1_thresh=0.3, enabled=True):
+    image = pipeline(
+    prompts,
+    num_inference_steps=50,
+    guidance_scale=3.5,
+    height=1024,
+    width=1024,
+    generator=torch.Generator(device="cuda").manual_seed(0),
+).images
+
+end_time = time.time()
+print(f"Time taken: {(end_time - start_time)} seconds")
+image[0].save(f"flux.1-dev-{precision}1-tc.png")
+image[1].save(f"flux.1-dev-{precision}2-tc.png")
+image[2].save(f"flux.1-dev-{precision}3-tc.png")

--- a/nunchaku/caching/utils.py
+++ b/nunchaku/caching/utils.py
@@ -860,9 +860,7 @@ class FluxCachedTransformerBlocks(nn.Module):
         rotary_emb_img = self.pack_rotemb(pad_tensor(rotary_emb_img, 256, 1))
         rotary_emb_single = self.pack_rotemb(pad_tensor(rotary_emb_single, 256, 1))
 
-        if (self.residual_diff_threshold_multi < 0.0) or (batch_size > 1):
-            if batch_size > 1 and self.verbose:
-                print("Batch size > 1 currently not supported")
+        if (self.residual_diff_threshold_multi < 0.0):
 
             hidden_states = self.m.forward(
                 hidden_states,


### PR DESCRIPTION
Close #597 

This PR addresses a critical bug in the `TeaCache` implementation that prevented correct batch processing.

The implementation has been refactored to be **batch-aware**.  This ensures that every sample in a batch is processed correctly without cross-sample interference.

Additionally, this PR removes some unnecessary and redundant code to improve overall clarity and maintainability.

### Key Changes

* **Corrected Batch Processing:** Refactored the caching mechanism, enabling proper batch processing.
* **Code Cleanup:** Removed unused variables and code blocks.

### How to Verify

1.  Run the model with a batch of diverse prompts (`batch_size` > 1).
2.  **Before this PR:** Observe that the outputs for samples `batch[1]` and onward are of poor quality and incorrectly influenced by `batch[0]`.
3.  **After this PR:** Confirm that all samples in the batch generate high-quality and correct images independently.


Results (batch 3 + TeaCache)
<img width="2191" height="728" alt="image" src="https://github.com/user-attachments/assets/ada73bd0-2dcb-4999-aec3-d98f138580a4" />

