### PR TITLE
Fix ValueError in NunchakuQwenImagePipeline.prepare_latents unpacking

### DIFF
--- a/nunchaku/pipeline/pipeline_qwenimage.py
+++ b/nunchaku/pipeline/pipeline_qwenimage.py
@@ -94,9 +94,9 @@ class NunchakuQwenImagePipeline(QwenImagePipeline):
                 max_sequence_length=max_sequence_length,
             )
 
-        # 4. Prepare latent variables  
+        # 4. Prepare latent variables
         num_channels_latents = self.transformer.config.in_channels // 4
-        
+
         # Get latents from parent method (returns single tensor)
         latents = super().prepare_latents(
             batch_size * num_images_per_prompt,
@@ -108,12 +108,12 @@ class NunchakuQwenImagePipeline(QwenImagePipeline):
             generator,
             latents,
         )
-        
+
         # Generate latent_image_ids manually
         seq_len = latents.shape[1] if len(latents.shape) > 1 else 0
         latent_image_ids = torch.arange(seq_len, device=device, dtype=torch.long)
         latent_image_ids = latent_image_ids.unsqueeze(0).repeat(batch_size * num_images_per_prompt, 1)
-        
+
         img_shapes = [(1, height // self.vae_scale_factor // 2, width // self.vae_scale_factor // 2)] * batch_size
 
         # 5. Prepare timesteps

--- a/nunchaku/pipeline/pipeline_qwenimage.py
+++ b/nunchaku/pipeline/pipeline_qwenimage.py
@@ -94,9 +94,11 @@ class NunchakuQwenImagePipeline(QwenImagePipeline):
                 max_sequence_length=max_sequence_length,
             )
 
-        # 4. Prepare latent variables
+        # 4. Prepare latent variables  
         num_channels_latents = self.transformer.config.in_channels // 4
-        latents, latent_image_ids = self.prepare_latents(
+        
+        # Get latents from parent method (returns single tensor)
+        latents = super().prepare_latents(
             batch_size * num_images_per_prompt,
             num_channels_latents,
             height,
@@ -106,6 +108,12 @@ class NunchakuQwenImagePipeline(QwenImagePipeline):
             generator,
             latents,
         )
+        
+        # Generate latent_image_ids manually
+        seq_len = latents.shape[1] if len(latents.shape) > 1 else 0
+        latent_image_ids = torch.arange(seq_len, device=device, dtype=torch.long)
+        latent_image_ids = latent_image_ids.unsqueeze(0).repeat(batch_size * num_images_per_prompt, 1)
+        
         img_shapes = [(1, height // self.vae_scale_factor // 2, width // self.vae_scale_factor // 2)] * batch_size
 
         # 5. Prepare timesteps


### PR DESCRIPTION
## Motivation
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Fix `ValueError: not enough values to unpack (expected 2, got 1)` in `NunchakuQwenImagePipeline` when calling the `prepare_latents` method. The pipeline was expecting `prepare_latents` to return a tuple of `(latents, latent_image_ids)`, but the parent class method only returns `latents` as a single tensor. This caused the pipeline to crash during inference with a unpacking error.

Fixes #614

## Modifications
<!-- Describe the changes made in this PR. -->
- Modified the `prepare_latents` call in `NunchakuQwenImagePipeline.__call__()` to handle the single return value from the parent method
- Added manual generation of `latent_image_ids` using `torch.arange()` to create the expected sequence IDs
- Ensured `latent_image_ids` has the correct shape `(batch_size * num_images_per_prompt, seq_len)` to match the latents tensor
- Maintained backward compatibility with the existing pipeline interface

**Changes made:**
1. Call `super().prepare_latents()` and assign result to `latents` (single tensor)
2. Generate `latent_image_ids` manually based on the latents sequence length
3. Ensure proper tensor shapes and device placement for `latent_image_ids`

### Sample Generated Images

| Image 1 | Image 2 |
|------------|-----------|
| ![image_1](https://github.com/user-attachments/assets/39b04722-a255-4a56-8904-b87622c4a484) | ![image_2](https://github.com/user-attachments/assets/e77ea5f8-c8a8-4be3-be91-19c6e05366c2) |

```
width:1664
height:928
num_inference_steps: 50
true_cfg_scale: 4.0
GPU: L40
CFG: 4.0
Time for generation: 60sec
```

## Checklist
- [x] Code is formatted using Pre-Commit hooks.
- [ ] Relevant unit [tests](https://claude.ai/tests) are added in the [`tests`](../tests) directory following the guidance in [`[Contribution Guide](https://nunchaku.tech/docs/nunchaku/developer/contribution_guide.html)`](https://nunchaku.tech/docs/nunchaku/developer/contribution_guide.html).
- [ ] [[Documentation](https://claude.ai/docs/source)](../docs/source) and example scripts in [`[examples](https://claude.ai/examples)`](../examples) are updated if necessary.
- [ ] Throughput/latency benchmarks and quality evaluations are included where applicable.
- [ ] **For reviewers:** If you're only helping merge the main branch and haven't contributed code to this PR, please remove yourself as a co-author when merging.
- [ ] Please feel free to join our [[Slack](https://join.slack.com/t/nunchaku/shared_invite/zt-3170agzoz-NgZzWaTrEj~n2KEV3Hpl5Q)](https://join.slack.com/t/nunchaku/shared_invite/zt-3170agzoz-NgZzWaTrEj~n2KEV3Hpl5Q), [[Discord](https://discord.gg/Wk6PnwX9Sm)](https://discord.gg/Wk6PnwX9Sm) or [[WeChat](https://github.com/mit-han-lab/nunchaku/blob/main/assets/wechat.jpg)](https://github.com/mit-han-lab/nunchaku/blob/main/assets/wechat.jpg) to discuss your PR.