### PR TITLE
feat: add rank calculation in merge_safetensors

### DIFF
--- a/nunchaku/merge_safetensors.py
+++ b/nunchaku/merge_safetensors.py
@@ -107,6 +107,8 @@ def merge_safetensors(
     state_dict = unquantized_part_sd
     state_dict.update(transformer_block_sd)
 
+    rank = next((v.shape[1] for k, v in transformer_block_sd.items() if ".lora_down" in k), 32)
+
     precision = "int4"
     for v in state_dict.values():
         assert isinstance(v, torch.Tensor)
@@ -130,6 +132,7 @@ def merge_safetensors(
             "scale_dtype": "fp8_e4m3_nan" if precision == "fp4" else None,
             "group_size": 16 if precision == "fp4" else 64,
         },
+        "rank": rank,
     }
     return state_dict, {
         "config": Path(config_path).read_text(),


### PR DESCRIPTION
<!-- Thank you for your contribution—we truly appreciate it! To help us review your pull request efficiently, please follow the guidelines below. If anything is unclear, feel free to open the PR and ask for clarification. You can also refer to our [contribution guide](./docs/contribution_guide.md) for more details. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
When using `python -m nunchaku.merge_safetensors`, if the rank of the quantized model is not 32, an error will be reported during loading because the rank value is not written in quantization_config.

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [x] Code is formatted using Pre-Commit hooks.
- [ ] Relevant unit tests are added in the [`tests`](../tests) directory following the guidance in [`Contribution Guide`](https://nunchaku.tech/docs/nunchaku/developer/contribution_guide.html).
- [ ] [Documentation](../docs/source) and example scripts in [`examples`](../examples) are updated if necessary.
- [ ] Throughput/latency benchmarks and quality evaluations are included where applicable.
- [ ] **For reviewers:** If you're only helping merge the main branch and haven't contributed code to this PR, please remove yourself as a co-author when merging.
- [ ] Please feel free to join our [Slack](https://join.slack.com/t/nunchaku/shared_invite/zt-3170agzoz-NgZzWaTrEj~n2KEV3Hpl5Q), [Discord](https://discord.gg/Wk6PnwX9Sm) or [WeChat](https://huggingface.co/datasets/nunchaku-tech/cdn/blob/main/nunchaku/assets/wechat.jpg) to discuss your PR.
