### PR TITLE
feat: introduce cache-dit to nunchaku

### DIFF
--- a/examples/v1/flux.1-dev-cache-dit.py
+++ b/examples/v1/flux.1-dev-cache-dit.py
@@ -1,0 +1,31 @@
+import cache_dit
+import torch
+from cache_dit import DBCacheConfig
+from diffusers import FluxPipeline
+
+from nunchaku.models.transformers.transformer_flux_v2 import NunchakuFluxTransformer2DModelV2
+from nunchaku.utils import get_precision
+
+precision = get_precision()  # auto-detect your precision is 'int4' or 'fp4' based on your GPU
+transformer = NunchakuFluxTransformer2DModelV2.from_pretrained(
+    f"nunchaku-tech/nunchaku-flux.1-dev/svdq-{precision}_r32-flux.1-dev.safetensors"
+)
+pipeline = FluxPipeline.from_pretrained(
+    "black-forest-labs/FLUX.1-dev", transformer=transformer, torch_dtype=torch.bfloat16
+).to("cuda")
+
+
+# Please check https://github.com/vipshop/cache-dit for more details about the parameters.
+cache_dit.enable_cache(
+    pipeline,
+    cache_config=DBCacheConfig(
+        Fn_compute_blocks=1,
+        Bn_compute_blocks=0,
+        residual_diff_threshold=0.12,
+    ),
+)
+
+image = pipeline("A cat holding a sign that says hello world", num_inference_steps=50, guidance_scale=3.5).images[0]
+image.save(f"flux.1-dev-cache-dit-{precision}.png")
+
+cache_dit.summary(pipeline)

--- a/examples/v1/qwen-image-cache-dit.py
+++ b/examples/v1/qwen-image-cache-dit.py
@@ -1,0 +1,59 @@
+import cache_dit
+import torch
+from cache_dit import DBCacheConfig
+from diffusers import QwenImagePipeline
+
+from nunchaku.models.transformers.transformer_qwenimage import NunchakuQwenImageTransformer2DModel
+from nunchaku.utils import get_gpu_memory, get_precision
+
+rank = 32  # you can also use rank=128 model to improve the quality
+
+# Load the model
+transformer = NunchakuQwenImageTransformer2DModel.from_pretrained(
+    f"nunchaku-tech/nunchaku-qwen-image/svdq-{get_precision()}_r{rank}-qwen-image.safetensors"
+)
+
+# currently, you need to use this pipeline to offload the model to CPU
+pipe = QwenImagePipeline.from_pretrained("Qwen/Qwen-Image", transformer=transformer, torch_dtype=torch.bfloat16)
+
+# Please check https://github.com/vipshop/cache-dit for more details about the parameters.
+
+cache_dit.enable_cache(
+    pipe,
+    cache_config=DBCacheConfig(
+        Fn_compute_blocks=8,
+        Bn_compute_blocks=0,
+        residual_diff_threshold=0.12,
+    ),
+)
+
+
+if get_gpu_memory() > 18:
+    pipe.enable_model_cpu_offload()
+else:
+    # use per-layer offloading for low VRAM. This only requires 3-4GB of VRAM.
+    transformer.set_offload(
+        True, use_pin_memory=False, num_blocks_on_gpu=1
+    )  # increase num_blocks_on_gpu if you have more VRAM
+    pipe._exclude_from_cpu_offload.append("transformer")
+    pipe.enable_sequential_cpu_offload()
+
+positive_magic = {
+    "en": "Ultra HD, 4K, cinematic composition.",  # for english prompt,
+    "zh": "超清，4K，电影级构图",  # for chinese prompt,
+}
+
+# Generate image
+prompt = """Bookstore window display. A sign displays “New Arrivals This Week”. Below, a shelf tag with the text “Best-Selling Novels Here”. To the side, a colorful poster advertises “Author Meet And Greet on Saturday” with a central portrait of the author. There are four books on the bookshelf, namely “The light between worlds” “When stars are scattered” “The slient patient” “The night circus”"""
+negative_prompt = " "  # using an empty string if you do not have specific concept to remove
+
+image = pipe(
+    prompt=prompt + positive_magic["en"],
+    negative_prompt=negative_prompt,
+    width=1664,
+    height=928,
+    num_inference_steps=50,
+    true_cfg_scale=4.0,
+).images[0]
+
+image.save(f"qwen-image-cache-dit-r{rank}.png")


### PR DESCRIPTION
This PR introduce cache-dit to nunchaku, support Qwen-Image and FLUX.1 series: inference w/ cache-dit + nunchaku 4-bits

@lmxyy 

## 📚Core Features of CacheDiT

- **[🎉Full 🤗Diffusers Support](https://github.com/vipshop/cache-dit/tree/main/docs/User_Guide.md#supported-pipelines)**: Notably, **[cache-dit](https://github.com/vipshop/cache-dit)** now supports nearly **all** of Diffusers' **DiT-based** pipelines, include **[30+](https://github.com/vipshop/cache-dit/tree/main/examples/pipeline/)** series, nearly **[100+](https://github.com/vipshop/cache-dit/tree/main/examples/pipeline/)** pipelines, such as FLUX.1, Qwen-Image, Qwen-Image-Lightning, Wan 2.1/2.2, HunyuanImage-2.1, HunyuanVideo, HiDream, AuraFlow, CogView3Plus, CogView4, CogVideoX, LTXVideo, ConsisID, SkyReelsV2, VisualCloze, PixArt, Chroma, Mochi, SD 3.5, DiT-XL, etc.  
- **[🎉Extremely Easy to Use](https://github.com/vipshop/cache-dit/tree/main/docs/User_Guide.md#unified-cache-apis)**: In most cases, you only need **one line** of code: `cache_dit.enable_cache(...)`. After calling this API, just use the pipeline as normal.   
- **[🎉Easy New Model Integration](https://github.com/vipshop/cache-dit/tree/main/docs/User_Guide.md#automatic-block-adapter)**: Features like **Unified Cache APIs**, **Forward Pattern Matching**, **Automatic Block Adapter**, **Hybrid Forward Pattern**, and **Patch Functor** make it highly functional and flexible. For example, we achieved 🎉 Day 1 support for [HunyuanImage-2.1](https://github.com/Tencent-Hunyuan/HunyuanImage-2.1) with 1.7x speedup w/o precision loss—even before it was available in the Diffusers library.  
- **[🎉State-of-the-Art Performance](https://github.com/vipshop/cache-dit/tree/main/bench/)**: Compared with algorithms including Δ-DiT, Chipmunk, FORA, DuCa, TaylorSeer and FoCa, cache-dit achieved the **SOTA** performance w/ **7.4x↑🎉** speedup on ClipScore!
- **[🎉Support for 4/8-Steps Distilled Models](https://github.com/vipshop/cache-dit/tree/main/bench/)**: Surprisingly, cache-dit's **DBCache** works for extremely few-step distilled models—something many other methods fail to do.  
- **[🎉Compatibility with Other Optimizations](https://github.com/vipshop/cache-dit/tree/main/docs/User_Guide.md#️torch-compile)**: Designed to work seamlessly with torch.compile, model CPU offload, sequential CPU offload, group offloading, Quantization(**[torchao](https://github.com/vipshop/cache-dit/tree/main/examples/quantize/)**, **[🔥nunchaku](https://github.com/vipshop/cache-dit/tree/main/examples/quantize/)**), etc.  
- **[🎉Hybrid Cache Acceleration](https://github.com/vipshop/cache-dit/tree/main/docs/User_Guide.md#taylorseer-calibrator)**: Now supports hybrid **Block-wise Cache + Calibrator** schemes (e.g., DBCache or DBPrune + TaylorSeerCalibrator). DBCache or DBPrune acts as the **Indicator** to decide *when* to cache, while the Calibrator decides *how* to cache. More mainstream cache acceleration algorithms (e.g., FoCa) will be supported in the future, along with additional benchmarks—stay tuned for updates!  

![](https://github.com/vipshop/cache-dit/raw/main/assets/clip-score-bench.png)

## Cases  

- FLUX.1-dev nunchaku 4-bits

<img width="1024" height="1024" alt="flux nunchaku int4 C0_L0_Q0_NONE" src="https://github.com/user-attachments/assets/cb1c5325-5fa9-46d6-bdb7-a1b6b3346eb9" />

- FLUX.1-dev nunchaku 4-bits w/ cache-dit, **~1.7x** speedup  

<img width="1024" height="1024" alt="flux nunchaku int4 C0_L0_Q0_DBCache_F1B0_W8I1M0MC0_R0 12_T0O0_S12" src="https://github.com/user-attachments/assets/e8ee2b18-b0a4-4270-bde2-6aff63ef50c8" />

- Qwen-Image nunchaku 4-bits

<img width="1664" height="928" alt="qwen-image nunchaku C0_L0_Q0_NONE" src="https://github.com/user-attachments/assets/1e6da8bd-27ce-4fad-99fe-00ee91b02af8" />

- Qwen-Image nunchaku 4-bits w/ cache-dit, **~1.8x** speedup  

<img width="1664" height="928" alt="qwen-image nunchaku C0_L0_Q0_DBCache_F1B0_W8I1M0MC0_R0 08_T0O0_S21" src="https://github.com/user-attachments/assets/be28c875-58ac-4469-a8a8-bdc5bb8e2bbb" />


## More examples  

🎉cache-dit now supported [**🔥nunchaku**](https://github.com/nunchaku-tech/nunchaku): Qwen-Image/FLUX.1 [4-bits examples](https://github.com/vipshop/cache-dit/tree/main/examples/quantize/) 

