### PR TITLE
Add SDXL FBCache Support

### DIFF
--- a/examples/v1/sdxl-cache.py
+++ b/examples/v1/sdxl-cache.py
@@ -1,0 +1,28 @@
+import torch
+from diffusers import StableDiffusionXLPipeline
+
+from nunchaku.caching.diffusers_adapters.sdxl import apply_cache_on_pipe
+from nunchaku.models.unets.unet_sdxl import NunchakuSDXLUNet2DConditionModel
+
+if __name__ == "__main__":
+    unet = NunchakuSDXLUNet2DConditionModel.from_pretrained(
+        "nunchaku-tech/nunchaku-sdxl/svdq-int4_r32-sdxl.safetensors"
+    )
+    pipeline = StableDiffusionXLPipeline.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0",
+        unet=unet,
+        torch_dtype=torch.bfloat16,
+        use_safetensors=True,
+        variant="fp16",
+    ).to("cuda")
+
+    # Apply FBCache to the pipeline
+    apply_cache_on_pipe(pipeline, residual_diff_threshold=0.12, verbose=True)
+
+    prompt = "A cinematic shot of a baby racoon wearing an intricate italian priest robe."
+
+    image = pipeline(
+        prompt=prompt, guidance_scale=5.0, generator=torch.Generator().manual_seed(23), num_inference_steps=50
+    ).images[0]
+
+    image.save("sdxl.png")

--- a/nunchaku/caching/diffusers_adapters/sdxl.py
+++ b/nunchaku/caching/diffusers_adapters/sdxl.py
@@ -1,0 +1,110 @@
+"""
+Adapters for efficient caching in SDXL diffusion pipelines.
+
+This module enables first-block caching for SDXL models, providing:
+
+- :func:`apply_cache_on_unet` — Add caching to a ``UNet2DConditionModel``.
+- :func:`apply_cache_on_pipe` — Add caching to a complete SDXL pipeline.
+
+Caching is context-managed and only active within a cache context.
+"""
+
+import functools
+
+from diffusers import DiffusionPipeline
+
+from .. import utils_sdxl
+from ..fbcache import cache_context, create_cache_context, get_current_cache_context
+
+
+def apply_cache_on_unet(unet, *, residual_diff_threshold=0.12, verbose=False):
+    """
+    Enable caching for a SDXL UNet2DConditionModel.
+
+    This function wraps the UNet's forward method to use caching for faster inference.
+    Uses single first-block caching with configurable similarity thresholds.
+
+    Parameters
+    ----------
+    unet : UNet2DConditionModel
+        The UNet to modify.
+    residual_diff_threshold : float, optional
+        Similarity threshold for caching (default: 0.12).
+    verbose : bool, optional
+        Print caching status messages (default: False).
+
+    Returns
+    -------
+    UNet2DConditionModel
+        The UNet with caching enabled.
+
+    Notes
+    -----
+    If already cached, returns the UNet unchanged. Caching is only active within a cache context.
+    """
+    if getattr(unet, "_is_cached", False):
+        return unet
+
+    # Store original forward method
+    unet._original_forward = unet.forward
+    unet.residual_diff_threshold = residual_diff_threshold
+    unet.verbose = verbose
+
+    # Replace forward with cached version
+    @functools.wraps(unet.forward)
+    def new_forward(*args, **kwargs):
+        cache_ctx = get_current_cache_context()
+        if cache_ctx is not None:
+            # Use cached forward
+            return utils_sdxl.cached_forward_sdxl(unet, *args, **kwargs)
+        else:
+            # Use original forward
+            return unet._original_forward(*args, **kwargs)
+
+    unet.forward = new_forward
+    unet._is_cached = True
+
+    return unet
+
+
+def apply_cache_on_pipe(pipe: DiffusionPipeline, *, residual_diff_threshold=0.12, verbose=False):
+    """
+    Enable caching for a complete SDXL diffusion pipeline.
+
+    This function wraps the pipeline's ``__call__`` method to manage cache contexts,
+    and applies UNet-level caching.
+
+    Parameters
+    ----------
+    pipe : DiffusionPipeline
+        The SDXL pipeline to modify.
+    residual_diff_threshold : float, optional
+        Similarity threshold for caching (default: 0.12).
+    verbose : bool, optional
+        Print caching status messages (default: False).
+
+    Returns
+    -------
+    DiffusionPipeline
+        The pipeline with caching enabled.
+
+    Notes
+    -----
+    The pipeline class's ``__call__`` is patched for all instances.
+    """
+    # Wrap pipeline __call__ with cache context
+    if not getattr(pipe, "_is_cached", False):
+        original_call = pipe.__class__.__call__
+
+        @functools.wraps(original_call)
+        def new_call(self, *args, **kwargs):
+            with cache_context(create_cache_context()):
+                return original_call(self, *args, **kwargs)
+
+        pipe.__class__.__call__ = new_call
+        pipe.__class__._is_cached = True
+
+    # Apply caching to UNet
+    apply_cache_on_unet(pipe.unet, residual_diff_threshold=residual_diff_threshold, verbose=verbose)
+
+    return pipe

--- a/nunchaku/caching/utils_sdxl.py
+++ b/nunchaku/caching/utils_sdxl.py
@@ -1,0 +1,620 @@
+"""
+Caching utilities for SDXL UNet2DConditionModel.
+
+Implements forward pass with caching support for SDXL UNet.
+
+**Main Functions**
+
+- :func:`cached_forward_sdxl` : Forward pass for SDXL UNet with caching support.
+"""
+
+from typing import Any, Dict, Optional, Tuple, Union
+
+import torch
+from diffusers.models.unets.unet_2d_condition import UNet2DConditionOutput
+from diffusers.utils import USE_PEFT_BACKEND, deprecate, scale_lora_layers, unscale_lora_layers
+
+from .fbcache import get_buffer, get_can_use_cache, set_buffer
+
+
+def cached_forward_sdxl(
+    self,
+    sample: torch.Tensor,
+    timestep: Union[torch.Tensor, float, int],
+    encoder_hidden_states: torch.Tensor,
+    class_labels: Optional[torch.Tensor] = None,
+    timestep_cond: Optional[torch.Tensor] = None,
+    attention_mask: Optional[torch.Tensor] = None,
+    cross_attention_kwargs: Optional[Dict[str, Any]] = None,
+    added_cond_kwargs: Optional[Dict[str, torch.Tensor]] = None,
+    down_block_additional_residuals: Optional[Tuple[torch.Tensor]] = None,
+    mid_block_additional_residual: Optional[torch.Tensor] = None,
+    down_intrablock_additional_residuals: Optional[Tuple[torch.Tensor]] = None,
+    encoder_attention_mask: Optional[torch.Tensor] = None,
+    return_dict: bool = True,
+) -> Union[UNet2DConditionOutput, Tuple]:
+    r"""
+    The [`UNet2DConditionModel`] forward method with caching support.
+
+    Args:
+        sample (`torch.Tensor`):
+            The noisy input tensor with the following shape `(batch, channel, height, width)`.
+        timestep (`torch.Tensor` or `float` or `int`): The number of timesteps to denoise an input.
+        encoder_hidden_states (`torch.Tensor`):
+            The encoder hidden states with shape `(batch, sequence_length, feature_dim)`.
+        class_labels (`torch.Tensor`, *optional*, defaults to `None`):
+            Optional class labels for conditioning. Their embeddings will be summed with the timestep embeddings.
+        timestep_cond: (`torch.Tensor`, *optional*, defaults to `None`):
+            Conditional embeddings for timestep. If provided, the embeddings will be summed with the samples passed
+            through the `self.time_embedding` layer to obtain the timestep embeddings.
+        attention_mask (`torch.Tensor`, *optional*, defaults to `None`):
+            An attention mask of shape `(batch, key_tokens)` is applied to `encoder_hidden_states`. If `1` the mask
+            is kept, otherwise if `0` it is discarded. Mask will be converted into a bias, which adds large
+            negative values to the attention scores corresponding to "discard" tokens.
+        cross_attention_kwargs (`dict`, *optional*):
+            A kwargs dictionary that if specified is passed along to the `AttentionProcessor` as defined under
+            `self.processor` in
+            [diffusers.models.attention_processor](https://github.com/huggingface/diffusers/blob/main/src/diffusers/models/attention_processor.py).
+        added_cond_kwargs: (`dict`, *optional*):
+            A kwargs dictionary containing additional embeddings that if specified are added to the embeddings that
+            are passed along to the UNet blocks.
+        down_block_additional_residuals: (`tuple` of `torch.Tensor`, *optional*):
+            A tuple of tensors that if specified are added to the residuals of down unet blocks.
+        mid_block_additional_residual: (`torch.Tensor`, *optional*):
+            A tensor that if specified is added to the residual of the middle unet block.
+        down_intrablock_additional_residuals (`tuple` of `torch.Tensor`, *optional*):
+            additional residuals to be added within UNet down blocks, for example from T2I-Adapter side model(s)
+        encoder_attention_mask (`torch.Tensor`):
+            A cross-attention mask of shape `(batch, sequence_length)` is applied to `encoder_hidden_states`. If
+            `True` the mask is kept, otherwise if `False` it is discarded. Mask will be converted into a bias,
+            which adds large negative values to the attention scores corresponding to "discard" tokens.
+        return_dict (`bool`, *optional*, defaults to `True`):
+            Whether or not to return a [`~models.unets.unet_2d_condition.UNet2DConditionOutput`] instead of a plain
+            tuple.
+
+    Returns:
+        [`~models.unets.unet_2d_condition.UNet2DConditionOutput`] or `tuple`:
+            If `return_dict` is True, an [`~models.unets.unet_2d_condition.UNet2DConditionOutput`] is returned,
+            otherwise a `tuple` is returned where the first element is the sample tensor.
+    """
+    # By default samples have to be AT least a multiple of the overall upsampling factor.
+    # The overall upsampling factor is equal to 2 ** (# num of upsampling layers).
+    # However, the upsampling interpolation output size can be forced to fit any upsampling size
+    # on the fly if necessary.
+    default_overall_up_factor = 2**self.num_upsamplers
+
+    # upsample size should be forwarded when sample is not a multiple of `default_overall_up_factor`
+    forward_upsample_size = False
+    upsample_size = None
+
+    for dim in sample.shape[-2:]:
+        if dim % default_overall_up_factor != 0:
+            # Forward upsample size to force interpolation output size.
+            forward_upsample_size = True
+            break
+
+    # ensure attention_mask is a bias, and give it a singleton query_tokens dimension
+    # expects mask of shape:
+    #   [batch, key_tokens]
+    # adds singleton query_tokens dimension:
+    #   [batch,                    1, key_tokens]
+    # this helps to broadcast it as a bias over attention scores, which will be in one of the following shapes:
+    #   [batch,  heads, query_tokens, key_tokens] (e.g. torch sdp attn)
+    #   [batch * heads, query_tokens, key_tokens] (e.g. xformers or classic attn)
+    if attention_mask is not None:
+        # assume that mask is expressed as:
+        #   (1 = keep,      0 = discard)
+        # convert mask into a bias that can be added to attention scores:
+        #       (keep = +0,     discard = -10000.0)
+        attention_mask = (1 - attention_mask.to(sample.dtype)) * -10000.0
+        attention_mask = attention_mask.unsqueeze(1)
+
+    # convert encoder_attention_mask to a bias the same way we do for attention_mask
+    if encoder_attention_mask is not None:
+        encoder_attention_mask = (1 - encoder_attention_mask.to(sample.dtype)) * -10000.0
+        encoder_attention_mask = encoder_attention_mask.unsqueeze(1)
+
+    # 0. center input if necessary
+    if self.config.center_input_sample:
+        sample = 2 * sample - 1.0
+
+    # 1. time
+    t_emb = self.get_time_embed(sample=sample, timestep=timestep)
+    emb = self.time_embedding(t_emb, timestep_cond)
+
+    class_emb = self.get_class_embed(sample=sample, class_labels=class_labels)
+    if class_emb is not None:
+        if self.config.class_embeddings_concat:
+            emb = torch.cat([emb, class_emb], dim=-1)
+        else:
+            emb = emb + class_emb
+
+    aug_emb = self.get_aug_embed(
+        emb=emb, encoder_hidden_states=encoder_hidden_states, added_cond_kwargs=added_cond_kwargs
+    )
+    if self.config.addition_embed_type == "image_hint":
+        aug_emb, hint = aug_emb
+        sample = torch.cat([sample, hint], dim=1)
+
+    emb = emb + aug_emb if aug_emb is not None else emb
+
+    if self.time_embed_act is not None:
+        emb = self.time_embed_act(emb)
+
+    encoder_hidden_states = self.process_encoder_hidden_states(
+        encoder_hidden_states=encoder_hidden_states, added_cond_kwargs=added_cond_kwargs
+    )
+
+    # 2. pre-process
+    sample = self.conv_in(sample)
+
+    # 2.5 GLIGEN position net
+    if cross_attention_kwargs is not None and cross_attention_kwargs.get("gligen", None) is not None:
+        cross_attention_kwargs = cross_attention_kwargs.copy()
+        gligen_args = cross_attention_kwargs.pop("gligen")
+        cross_attention_kwargs["gligen"] = {"objs": self.position_net(**gligen_args)}
+
+    # 3. down
+    # we're popping the `scale` instead of getting it because otherwise `scale` will be propagated
+    # to the internal blocks and will raise deprecation warnings. this will be confusing for our users.
+    if cross_attention_kwargs is not None:
+        cross_attention_kwargs = cross_attention_kwargs.copy()
+        lora_scale = cross_attention_kwargs.pop("scale", 1.0)
+    else:
+        lora_scale = 1.0
+
+    if USE_PEFT_BACKEND:
+        # weight the lora layers by setting `lora_scale` for each PEFT layer
+        scale_lora_layers(self, lora_scale)
+
+    is_controlnet = mid_block_additional_residual is not None and down_block_additional_residuals is not None
+    # using new arg down_intrablock_additional_residuals for T2I-Adapters, to distinguish from controlnets
+    is_adapter = down_intrablock_additional_residuals is not None
+    # maintain backward compatibility for legacy usage, where
+    #       T2I-Adapter and ControlNet both use down_block_additional_residuals arg
+    #       but can only use one or the other
+    if not is_adapter and mid_block_additional_residual is None and down_block_additional_residuals is not None:
+        deprecate(
+            "T2I should not use down_block_additional_residuals",
+            "1.3.0",
+            "Passing intrablock residual connections with `down_block_additional_residuals` is deprecated \
+                   and will be removed in diffusers 1.3.0.  `down_block_additional_residuals` should only be used \
+                   for ControlNet. Please make sure use `down_intrablock_additional_residuals` instead. ",
+            standard_warn=False,
+        )
+        down_intrablock_additional_residuals = down_block_additional_residuals
+        is_adapter = True
+
+    down_block_res_samples = (sample,)
+
+    # 3.2 FBCache: Process first down_block
+    first_block = self.down_blocks[0]
+    if hasattr(first_block, "has_cross_attention") and first_block.has_cross_attention:
+        # For t2i-adapter CrossAttnDownBlock2D
+        additional_residuals = {}
+        if is_adapter and len(down_intrablock_additional_residuals) > 0:
+            additional_residuals["additional_residuals"] = down_intrablock_additional_residuals.pop(0)
+
+        sample, res_samples = first_block(
+            hidden_states=sample,
+            temb=emb,
+            encoder_hidden_states=encoder_hidden_states,
+            attention_mask=attention_mask,
+            cross_attention_kwargs=cross_attention_kwargs,
+            encoder_attention_mask=encoder_attention_mask,
+            **additional_residuals,
+        )
+    else:
+        sample, res_samples = first_block(hidden_states=sample, temb=emb)
+        if is_adapter and len(down_intrablock_additional_residuals) > 0:
+            sample += down_intrablock_additional_residuals.pop(0)
+    down_block_res_samples += res_samples
+
+    # 3.3 FBCache: Check cache using first block output sample
+    can_use_cache, diff = get_can_use_cache(
+        sample,
+        threshold=self.residual_diff_threshold,
+        parallelized=False,
+        mode="single",
+    )
+
+    # 3.4 FBCache: Apply caching logic
+    torch._dynamo.graph_break()
+    if can_use_cache:
+        if self.verbose:
+            print(f"[SDXL] Cache hit!!! (diff: {diff:.6f})")
+        # Skip all remaining computation and get final output (after post-process)
+        sample = get_buffer("final_output")
+    else:
+        if self.verbose:
+            print(f"[SDXL] Cache miss!!! (diff: {diff:.6f})")
+        # Store first block output for next comparison
+        set_buffer("first_single_hidden_states_residual", sample)
+
+        # Make a copy to preserve state
+        down_intrablock_additional_residuals_copy = list(down_intrablock_additional_residuals) if is_adapter else []
+
+        # Process remaining down blocks
+        for downsample_block in self.down_blocks[1:]:
+            if hasattr(downsample_block, "has_cross_attention") and downsample_block.has_cross_attention:
+                # For t2i-adapter CrossAttnDownBlock2D
+                additional_residuals = {}
+                if is_adapter and len(down_intrablock_additional_residuals_copy) > 0:
+                    additional_residuals["additional_residuals"] = down_intrablock_additional_residuals_copy.pop(0)
+
+                sample, res_samples = downsample_block(
+                    hidden_states=sample,
+                    temb=emb,
+                    encoder_hidden_states=encoder_hidden_states,
+                    attention_mask=attention_mask,
+                    cross_attention_kwargs=cross_attention_kwargs,
+                    encoder_attention_mask=encoder_attention_mask,
+                    **additional_residuals,
+                )
+            else:
+                sample, res_samples = downsample_block(hidden_states=sample, temb=emb)
+                if is_adapter and len(down_intrablock_additional_residuals_copy) > 0:
+                    sample += down_intrablock_additional_residuals_copy.pop(0)
+
+            down_block_res_samples += res_samples
+
+        if is_controlnet:
+            new_down_block_res_samples = ()
+
+            for down_block_res_sample, down_block_additional_residual in zip(
+                down_block_res_samples, down_block_additional_residuals
+            ):
+                down_block_res_sample = down_block_res_sample + down_block_additional_residual
+                new_down_block_res_samples = new_down_block_res_samples + (down_block_res_sample,)
+
+            down_block_res_samples = new_down_block_res_samples
+
+        # 4. mid
+        if self.mid_block is not None:
+            if hasattr(self.mid_block, "has_cross_attention") and self.mid_block.has_cross_attention:
+                sample = self.mid_block(
+                    sample,
+                    emb,
+                    encoder_hidden_states=encoder_hidden_states,
+                    attention_mask=attention_mask,
+                    cross_attention_kwargs=cross_attention_kwargs,
+                    encoder_attention_mask=encoder_attention_mask,
+                )
+            else:
+                sample = self.mid_block(sample, emb)
+
+            # To support T2I-Adapter-XL
+            if (
+                is_adapter
+                and len(down_intrablock_additional_residuals_copy) > 0
+                and sample.shape == down_intrablock_additional_residuals_copy[0].shape
+            ):
+                sample += down_intrablock_additional_residuals_copy.pop(0)
+
+        if is_controlnet:
+            sample = sample + mid_block_additional_residual
+
+        # 5. up
+        for i, upsample_block in enumerate(self.up_blocks):
+            is_final_block = i == len(self.up_blocks) - 1
+
+            res_samples = down_block_res_samples[-len(upsample_block.resnets) :]
+            down_block_res_samples = down_block_res_samples[: -len(upsample_block.resnets)]
+
+            # if we have not reached the final block and need to forward the
+            # upsample size, we do it here
+            if not is_final_block and forward_upsample_size:
+                upsample_size = down_block_res_samples[-1].shape[2:]
+
+            if hasattr(upsample_block, "has_cross_attention") and upsample_block.has_cross_attention:
+                sample = upsample_block(
+                    hidden_states=sample,
+                    temb=emb,
+                    res_hidden_states_tuple=res_samples,
+                    encoder_hidden_states=encoder_hidden_states,
+                    cross_attention_kwargs=cross_attention_kwargs,
+                    upsample_size=upsample_size,
+                    attention_mask=attention_mask,
+                    encoder_attention_mask=encoder_attention_mask,
+                )
+            else:
+                sample = upsample_block(
+                    hidden_states=sample,
+                    temb=emb,
+                    res_hidden_states_tuple=res_samples,
+                    upsample_size=upsample_size,
+                )
+
+        # 6. post-process
+        if self.conv_norm_out:
+            sample = self.conv_norm_out(sample)
+            sample = self.conv_act(sample)
+        sample = self.conv_out(sample)
+
+        # Store final output (after post-process) for next inference
+        set_buffer("final_output", sample)
+    torch._dynamo.graph_break()
+
+    if USE_PEFT_BACKEND:
+        # remove `lora_scale` from each PEFT layer
+        unscale_lora_layers(self, lora_scale)
+
+    if not return_dict:
+        return (sample,)
+
+    return UNet2DConditionOutput(sample=sample)
+
+
+def orig_forward_sdxl(
+    self,
+    sample: torch.Tensor,
+    timestep: Union[torch.Tensor, float, int],
+    encoder_hidden_states: torch.Tensor,
+    class_labels: Optional[torch.Tensor] = None,
+    timestep_cond: Optional[torch.Tensor] = None,
+    attention_mask: Optional[torch.Tensor] = None,
+    cross_attention_kwargs: Optional[Dict[str, Any]] = None,
+    added_cond_kwargs: Optional[Dict[str, torch.Tensor]] = None,
+    down_block_additional_residuals: Optional[Tuple[torch.Tensor]] = None,
+    mid_block_additional_residual: Optional[torch.Tensor] = None,
+    down_intrablock_additional_residuals: Optional[Tuple[torch.Tensor]] = None,
+    encoder_attention_mask: Optional[torch.Tensor] = None,
+    return_dict: bool = True,
+) -> Union[UNet2DConditionOutput, Tuple]:
+    r"""
+    The [`UNet2DConditionModel`] forward method with caching support.
+
+    Args:
+        sample (`torch.Tensor`):
+            The noisy input tensor with the following shape `(batch, channel, height, width)`.
+        timestep (`torch.Tensor` or `float` or `int`): The number of timesteps to denoise an input.
+        encoder_hidden_states (`torch.Tensor`):
+            The encoder hidden states with shape `(batch, sequence_length, feature_dim)`.
+        class_labels (`torch.Tensor`, *optional*, defaults to `None`):
+            Optional class labels for conditioning. Their embeddings will be summed with the timestep embeddings.
+        timestep_cond: (`torch.Tensor`, *optional*, defaults to `None`):
+            Conditional embeddings for timestep. If provided, the embeddings will be summed with the samples passed
+            through the `self.time_embedding` layer to obtain the timestep embeddings.
+        attention_mask (`torch.Tensor`, *optional*, defaults to `None`):
+            An attention mask of shape `(batch, key_tokens)` is applied to `encoder_hidden_states`. If `1` the mask
+            is kept, otherwise if `0` it is discarded. Mask will be converted into a bias, which adds large
+            negative values to the attention scores corresponding to "discard" tokens.
+        cross_attention_kwargs (`dict`, *optional*):
+            A kwargs dictionary that if specified is passed along to the `AttentionProcessor` as defined under
+            `self.processor` in
+            [diffusers.models.attention_processor](https://github.com/huggingface/diffusers/blob/main/src/diffusers/models/attention_processor.py).
+        added_cond_kwargs: (`dict`, *optional*):
+            A kwargs dictionary containing additional embeddings that if specified are added to the embeddings that
+            are passed along to the UNet blocks.
+        down_block_additional_residuals: (`tuple` of `torch.Tensor`, *optional*):
+            A tuple of tensors that if specified are added to the residuals of down unet blocks.
+        mid_block_additional_residual: (`torch.Tensor`, *optional*):
+            A tensor that if specified is added to the residual of the middle unet block.
+        down_intrablock_additional_residuals (`tuple` of `torch.Tensor`, *optional*):
+            additional residuals to be added within UNet down blocks, for example from T2I-Adapter side model(s)
+        encoder_attention_mask (`torch.Tensor`):
+            A cross-attention mask of shape `(batch, sequence_length)` is applied to `encoder_hidden_states`. If
+            `True` the mask is kept, otherwise if `False` it is discarded. Mask will be converted into a bias,
+            which adds large negative values to the attention scores corresponding to "discard" tokens.
+        return_dict (`bool`, *optional*, defaults to `True`):
+            Whether or not to return a [`~models.unets.unet_2d_condition.UNet2DConditionOutput`] instead of a plain
+            tuple.
+
+    Returns:
+        [`~models.unets.unet_2d_condition.UNet2DConditionOutput`] or `tuple`:
+            If `return_dict` is True, an [`~models.unets.unet_2d_condition.UNet2DConditionOutput`] is returned,
+            otherwise a `tuple` is returned where the first element is the sample tensor.
+    """
+    # By default samples have to be AT least a multiple of the overall upsampling factor.
+    # The overall upsampling factor is equal to 2 ** (# num of upsampling layers).
+    # However, the upsampling interpolation output size can be forced to fit any upsampling size
+    # on the fly if necessary.
+    default_overall_up_factor = 2**self.num_upsamplers
+
+    # upsample size should be forwarded when sample is not a multiple of `default_overall_up_factor`
+    forward_upsample_size = False
+    upsample_size = None
+
+    for dim in sample.shape[-2:]:
+        if dim % default_overall_up_factor != 0:
+            # Forward upsample size to force interpolation output size.
+            forward_upsample_size = True
+            break
+
+    # ensure attention_mask is a bias, and give it a singleton query_tokens dimension
+    # expects mask of shape:
+    #   [batch, key_tokens]
+    # adds singleton query_tokens dimension:
+    #   [batch,                    1, key_tokens]
+    # this helps to broadcast it as a bias over attention scores, which will be in one of the following shapes:
+    #   [batch,  heads, query_tokens, key_tokens] (e.g. torch sdp attn)
+    #   [batch * heads, query_tokens, key_tokens] (e.g. xformers or classic attn)
+    if attention_mask is not None:
+        # assume that mask is expressed as:
+        #   (1 = keep,      0 = discard)
+        # convert mask into a bias that can be added to attention scores:
+        #       (keep = +0,     discard = -10000.0)
+        attention_mask = (1 - attention_mask.to(sample.dtype)) * -10000.0
+        attention_mask = attention_mask.unsqueeze(1)
+
+    # convert encoder_attention_mask to a bias the same way we do for attention_mask
+    if encoder_attention_mask is not None:
+        encoder_attention_mask = (1 - encoder_attention_mask.to(sample.dtype)) * -10000.0
+        encoder_attention_mask = encoder_attention_mask.unsqueeze(1)
+
+    # 0. center input if necessary
+    if self.config.center_input_sample:
+        sample = 2 * sample - 1.0
+
+    # 1. time
+    t_emb = self.get_time_embed(sample=sample, timestep=timestep)
+    emb = self.time_embedding(t_emb, timestep_cond)
+
+    class_emb = self.get_class_embed(sample=sample, class_labels=class_labels)
+    if class_emb is not None:
+        if self.config.class_embeddings_concat:
+            emb = torch.cat([emb, class_emb], dim=-1)
+        else:
+            emb = emb + class_emb
+
+    aug_emb = self.get_aug_embed(
+        emb=emb, encoder_hidden_states=encoder_hidden_states, added_cond_kwargs=added_cond_kwargs
+    )
+    if self.config.addition_embed_type == "image_hint":
+        aug_emb, hint = aug_emb
+        sample = torch.cat([sample, hint], dim=1)
+
+    emb = emb + aug_emb if aug_emb is not None else emb
+
+    if self.time_embed_act is not None:
+        emb = self.time_embed_act(emb)
+
+    encoder_hidden_states = self.process_encoder_hidden_states(
+        encoder_hidden_states=encoder_hidden_states, added_cond_kwargs=added_cond_kwargs
+    )
+
+    # 2. pre-process
+    sample = self.conv_in(sample)
+
+    # 2.5 GLIGEN position net
+    if cross_attention_kwargs is not None and cross_attention_kwargs.get("gligen", None) is not None:
+        cross_attention_kwargs = cross_attention_kwargs.copy()
+        gligen_args = cross_attention_kwargs.pop("gligen")
+        cross_attention_kwargs["gligen"] = {"objs": self.position_net(**gligen_args)}
+
+    # 3. down
+    # we're popping the `scale` instead of getting it because otherwise `scale` will be propagated
+    # to the internal blocks and will raise deprecation warnings. this will be confusing for our users.
+    if cross_attention_kwargs is not None:
+        cross_attention_kwargs = cross_attention_kwargs.copy()
+        lora_scale = cross_attention_kwargs.pop("scale", 1.0)
+    else:
+        lora_scale = 1.0
+
+    if USE_PEFT_BACKEND:
+        # weight the lora layers by setting `lora_scale` for each PEFT layer
+        scale_lora_layers(self, lora_scale)
+
+    is_controlnet = mid_block_additional_residual is not None and down_block_additional_residuals is not None
+    # using new arg down_intrablock_additional_residuals for T2I-Adapters, to distinguish from controlnets
+    is_adapter = down_intrablock_additional_residuals is not None
+    # maintain backward compatibility for legacy usage, where
+    #       T2I-Adapter and ControlNet both use down_block_additional_residuals arg
+    #       but can only use one or the other
+    if not is_adapter and mid_block_additional_residual is None and down_block_additional_residuals is not None:
+        deprecate(
+            "T2I should not use down_block_additional_residuals",
+            "1.3.0",
+            "Passing intrablock residual connections with `down_block_additional_residuals` is deprecated \
+                   and will be removed in diffusers 1.3.0.  `down_block_additional_residuals` should only be used \
+                   for ControlNet. Please make sure use `down_intrablock_additional_residuals` instead. ",
+            standard_warn=False,
+        )
+        down_intrablock_additional_residuals = down_block_additional_residuals
+        is_adapter = True
+
+    down_block_res_samples = (sample,)
+    for downsample_block in self.down_blocks:
+        if hasattr(downsample_block, "has_cross_attention") and downsample_block.has_cross_attention:
+            # For t2i-adapter CrossAttnDownBlock2D
+            additional_residuals = {}
+            if is_adapter and len(down_intrablock_additional_residuals) > 0:
+                additional_residuals["additional_residuals"] = down_intrablock_additional_residuals.pop(0)
+
+            sample, res_samples = downsample_block(
+                hidden_states=sample,
+                temb=emb,
+                encoder_hidden_states=encoder_hidden_states,
+                attention_mask=attention_mask,
+                cross_attention_kwargs=cross_attention_kwargs,
+                encoder_attention_mask=encoder_attention_mask,
+                **additional_residuals,
+            )
+        else:
+            sample, res_samples = downsample_block(hidden_states=sample, temb=emb)
+            if is_adapter and len(down_intrablock_additional_residuals) > 0:
+                sample += down_intrablock_additional_residuals.pop(0)
+
+        down_block_res_samples += res_samples
+
+    if is_controlnet:
+        new_down_block_res_samples = ()
+
+        for down_block_res_sample, down_block_additional_residual in zip(
+            down_block_res_samples, down_block_additional_residuals
+        ):
+            down_block_res_sample = down_block_res_sample + down_block_additional_residual
+            new_down_block_res_samples = new_down_block_res_samples + (down_block_res_sample,)
+
+        down_block_res_samples = new_down_block_res_samples
+
+    # 4. mid
+    if self.mid_block is not None:
+        if hasattr(self.mid_block, "has_cross_attention") and self.mid_block.has_cross_attention:
+            sample = self.mid_block(
+                sample,
+                emb,
+                encoder_hidden_states=encoder_hidden_states,
+                attention_mask=attention_mask,
+                cross_attention_kwargs=cross_attention_kwargs,
+                encoder_attention_mask=encoder_attention_mask,
+            )
+        else:
+            sample = self.mid_block(sample, emb)
+
+        # To support T2I-Adapter-XL
+        if (
+            is_adapter
+            and len(down_intrablock_additional_residuals) > 0
+            and sample.shape == down_intrablock_additional_residuals[0].shape
+        ):
+            sample += down_intrablock_additional_residuals.pop(0)
+
+    if is_controlnet:
+        sample = sample + mid_block_additional_residual
+
+    # 5. up
+    for i, upsample_block in enumerate(self.up_blocks):
+        is_final_block = i == len(self.up_blocks) - 1
+
+        res_samples = down_block_res_samples[-len(upsample_block.resnets) :]
+        down_block_res_samples = down_block_res_samples[: -len(upsample_block.resnets)]
+
+        # if we have not reached the final block and need to forward the
+        # upsample size, we do it here
+        if not is_final_block and forward_upsample_size:
+            upsample_size = down_block_res_samples[-1].shape[2:]
+
+        if hasattr(upsample_block, "has_cross_attention") and upsample_block.has_cross_attention:
+            sample = upsample_block(
+                hidden_states=sample,
+                temb=emb,
+                res_hidden_states_tuple=res_samples,
+                encoder_hidden_states=encoder_hidden_states,
+                cross_attention_kwargs=cross_attention_kwargs,
+                upsample_size=upsample_size,
+                attention_mask=attention_mask,
+                encoder_attention_mask=encoder_attention_mask,
+            )
+        else:
+            sample = upsample_block(
+                hidden_states=sample,
+                temb=emb,
+                res_hidden_states_tuple=res_samples,
+                upsample_size=upsample_size,
+            )
+
+    # 6. post-process
+    if self.conv_norm_out:
+        sample = self.conv_norm_out(sample)
+        sample = self.conv_act(sample)
+    sample = self.conv_out(sample)
+
+    if USE_PEFT_BACKEND:
+        # remove `lora_scale` from each PEFT layer
+        unscale_lora_layers(self, lora_scale)
+
+    if not return_dict:
+        return (sample,)
+
+    return UNet2DConditionOutput(sample=sample)

--- a/tests/v1/sdxl/test_sdxl_cache.py
+++ b/tests/v1/sdxl/test_sdxl_cache.py
@@ -1,0 +1,234 @@
+import gc
+import os
+from pathlib import Path
+
+import pytest
+import torch
+from diffusers import StableDiffusionXLPipeline
+
+from nunchaku.caching.diffusers_adapters.sdxl import apply_cache_on_pipe
+from nunchaku.models.unets.unet_sdxl import NunchakuSDXLUNet2DConditionModel
+from nunchaku.utils import get_precision, is_turing
+
+from ...flux.utils import already_generate, compute_lpips, hash_str_to_int
+
+
+@pytest.mark.skipif(
+    is_turing() or get_precision() == "fp4", reason="Skip tests due to using Turing GPUs or FP4 precision"
+)
+@pytest.mark.parametrize("expected_lpips", [0.25 if get_precision() == "int4" else 0.18])
+def test_sdxl_cache_lpips(expected_lpips: float):
+    """Test SDXL with FBCache enabled - verify quality is maintained."""
+    gc.collect()
+    torch.cuda.empty_cache()
+
+    precision = get_precision()
+
+    ref_root = Path(os.environ.get("NUNCHAKU_TEST_CACHE_ROOT", os.path.join("test_results", "ref")))
+    results_dir_original = ref_root / "fp16" / "sdxl"
+    results_dir_cached = ref_root / precision / "sdxl_cached"
+
+    os.makedirs(results_dir_original, exist_ok=True)
+    os.makedirs(results_dir_cached, exist_ok=True)
+
+    prompts = [
+        "Ilya Repin, Moebius, Yoshitaka Amano, 1980s nubian punk rock glam core fashion shoot, closeup, 35mm ",
+        "A honeybee sitting on a flower in a garden full of yellow flowers",
+        "Vibrant, tropical rainforest, teeming with wildlife, nature photography ",
+        "very realistic photo of barak obama in a wing eating contest",
+        "oil paint of colorful wildflowers in a meadow, Paul Signac divisionism style ",
+    ]
+
+    # Generate reference images if not exists
+    if not already_generate(results_dir_original, 5):
+        pipeline = StableDiffusionXLPipeline.from_pretrained(
+            "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.bfloat16, use_safetensors=True, variant="fp16"
+        ).to("cuda")
+
+        for prompt in prompts:
+            seed = hash_str_to_int(prompt)
+            result = pipeline(
+                prompt=prompt, guidance_scale=5.0, num_inference_steps=50, generator=torch.Generator().manual_seed(seed)
+            ).images[0]
+            result.save(os.path.join(results_dir_original, f"{seed}.png"))
+
+        del pipeline.unet
+        del pipeline.text_encoder
+        del pipeline.text_encoder_2
+        del pipeline.vae
+        del pipeline
+        del result
+        gc.collect()
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+
+    free, total = torch.cuda.mem_get_info()
+    print(f"After original generation: Free: {free/1024**2:.0f} MB  /  Total: {total/1024**2:.0f} MB")
+
+    # Generate images with cache enabled
+    if not already_generate(results_dir_cached, 5):
+        quantized_unet = NunchakuSDXLUNet2DConditionModel.from_pretrained(
+            "nunchaku-tech/nunchaku-sdxl/svdq-int4_r32-sdxl.safetensors"
+        )
+        pipeline = StableDiffusionXLPipeline.from_pretrained(
+            "stabilityai/stable-diffusion-xl-base-1.0",
+            unet=quantized_unet,
+            torch_dtype=torch.bfloat16,
+            use_safetensors=True,
+            variant="fp16",
+        )
+        pipeline.unet = quantized_unet
+        pipeline = pipeline.to("cuda")
+
+        # Apply FBCache
+        apply_cache_on_pipe(pipeline, residual_diff_threshold=0.12, verbose=True)
+
+        for prompt in prompts:
+            seed = hash_str_to_int(prompt)
+            result = pipeline(
+                prompt=prompt, guidance_scale=5.0, num_inference_steps=50, generator=torch.Generator().manual_seed(seed)
+            ).images[0]
+            result.save(os.path.join(results_dir_cached, f"{seed}.png"))
+
+        del pipeline
+        del quantized_unet
+        gc.collect()
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+
+    free, total = torch.cuda.mem_get_info()
+    print(f"After cached generation: Free: {free/1024**2:.0f} MB  /  Total: {total/1024**2:.0f} MB")
+
+    # Compare quality
+    lpips = compute_lpips(results_dir_original, results_dir_cached)
+    print(f"LPIPS (with cache): {lpips}")
+    assert lpips < expected_lpips * 1.15
+
+
+@pytest.mark.skipif(
+    is_turing() or get_precision() == "fp4", reason="Skip tests due to using Turing GPUs or FP4 precision"
+)
+def test_sdxl_cache_functionality():
+    """Test that cache hit/miss mechanism works correctly."""
+    gc.collect()
+    torch.cuda.empty_cache()
+
+    quantized_unet = NunchakuSDXLUNet2DConditionModel.from_pretrained(
+        "nunchaku-tech/nunchaku-sdxl/svdq-int4_r32-sdxl.safetensors"
+    )
+    pipeline = StableDiffusionXLPipeline.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0",
+        unet=quantized_unet,
+        torch_dtype=torch.bfloat16,
+        use_safetensors=True,
+        variant="fp16",
+    ).to("cuda")
+
+    # Apply FBCache with verbose to see cache hit/miss
+    apply_cache_on_pipe(pipeline, residual_diff_threshold=0.12, verbose=True)
+
+    prompt = "A cinematic shot of a baby racoon wearing an intricate italian priest robe."
+
+    print("\nGenerating with cache enabled - should see cache messages:")
+    image = pipeline(
+        prompt=prompt,
+        guidance_scale=5.0,
+        num_inference_steps=10,  # Use fewer steps for faster testing
+        generator=torch.Generator().manual_seed(42),
+    ).images[0]
+
+    # Verify image was generated
+    assert image is not None
+    assert image.size[0] > 0 and image.size[1] > 0
+
+    del pipeline
+    del quantized_unet
+    gc.collect()
+    torch.cuda.empty_cache()
+
+    print("Cache functionality test passed!")
+
+
+@pytest.mark.skipif(
+    is_turing() or get_precision() == "fp4", reason="Skip tests due to using Turing GPUs or FP4 precision"
+)
+def test_sdxl_cache_vs_no_cache():
+    """Compare outputs with and without cache to ensure they match."""
+    gc.collect()
+    torch.cuda.empty_cache()
+
+    quantized_unet = NunchakuSDXLUNet2DConditionModel.from_pretrained(
+        "nunchaku-tech/nunchaku-sdxl/svdq-int4_r32-sdxl.safetensors"
+    )
+
+    # First run without cache
+    pipeline_no_cache = StableDiffusionXLPipeline.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0",
+        unet=quantized_unet,
+        torch_dtype=torch.bfloat16,
+        use_safetensors=True,
+        variant="fp16",
+    ).to("cuda")
+
+    prompt = "A beautiful sunset over mountains"
+    seed = 123
+
+    print("\nGenerating without cache:")
+    image_no_cache = pipeline_no_cache(
+        prompt=prompt, guidance_scale=5.0, num_inference_steps=10, generator=torch.Generator().manual_seed(seed)
+    ).images[0]
+
+    del pipeline_no_cache
+    gc.collect()
+    torch.cuda.empty_cache()
+
+    # Second run with cache
+    quantized_unet_2 = NunchakuSDXLUNet2DConditionModel.from_pretrained(
+        "nunchaku-tech/nunchaku-sdxl/svdq-int4_r32-sdxl.safetensors"
+    )
+    pipeline_cache = StableDiffusionXLPipeline.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0",
+        unet=quantized_unet_2,
+        torch_dtype=torch.bfloat16,
+        use_safetensors=True,
+        variant="fp16",
+    ).to("cuda")
+
+    apply_cache_on_pipe(pipeline_cache, residual_diff_threshold=0.12, verbose=True)
+
+    print("\nGenerating with cache:")
+    image_cache = pipeline_cache(
+        prompt=prompt, guidance_scale=5.0, num_inference_steps=10, generator=torch.Generator().manual_seed(seed)
+    ).images[0]
+
+    # Save both for visual comparison
+    ref_root = Path(os.environ.get("NUNCHAKU_TEST_CACHE_ROOT", os.path.join("test_results", "ref")))
+    comparison_dir = ref_root / "cache_comparison"
+    os.makedirs(comparison_dir, exist_ok=True)
+
+    image_no_cache.save(comparison_dir / "no_cache.png")
+    image_cache.save(comparison_dir / "with_cache.png")
+
+    # Images should be very similar (deterministic with same seed)
+    # Convert to tensors and compute difference
+    import torchvision.transforms as T
+
+    to_tensor = T.ToTensor()
+
+    tensor_no_cache = to_tensor(image_no_cache)
+    tensor_cache = to_tensor(image_cache)
+
+    # Compute mean absolute difference
+    diff = (tensor_no_cache - tensor_cache).abs().mean().item()
+    print(f"\nMean absolute difference: {diff}")
+
+    # Difference should be small (allowing for numerical variations from caching)
+    # Note: Cache miss still runs all blocks, but with slight numerical differences
+    assert diff < 0.02, f"Images differ too much: {diff}"
+
+    del pipeline_cache
+    del quantized_unet_2
+    gc.collect()
+    torch.cuda.empty_cache()
+
+    print("Cache comparison test passed!")


### PR DESCRIPTION
##  Feat: Implement FBCache (First Block Cache) Optimization for SDXL Pipeline

### Overview

This PR introduces the **FBCache (First Block Cache)** optimization to the Stable Diffusion XL (SDXL) inference pipeline, accelerating inference by skipping redundant computations.

### How FBCache Works

FBCache uses the **U-Net's first down-sampling block (First Down Block)** as this proxy. 
The implementation of this forward pass references the design of the Hugging Face diffusers library to maintain consistency with its pipeline architecture.


### Performance Improvement (Acceleration)

With this optimization, inference speed for a 50-step SDXL generation on an **NVIDIA A5000 GPU** was significantly improved.

* **Before (No Cache)**: $\approx$ **7 seconds**
    * *Attached Image:<img width="1024" height="1024" alt="no cache(7s) sdxl" src="https://github.com/user-attachments/assets/b0dbdef9-f00e-4e53-ab2d-97dac2686754" />*


* **After (FBCache)**: $\approx$ **2 seconds**
    * *Attached Image: <img width="1024" height="1024" alt="cache(2s) sdxl" src="https://github.com/user-attachments/assets/d9f61cfa-55f8-4a31-bf04-0d342b1c83c6" />*

This represents an approximate **3.5x inference speedup**. This result demonstrates that the cache effectively skips the majority of U-Net computations in the later timesteps. The attached images show identical quality output, confirming the optimization's effectiveness.