### PR TITLE
feat: Enable deterministic LoRA activation reduction using fixed-point arithmetic

### DIFF
--- a/src/kernels/zgemm/gemm_utils.cuh
+++ b/src/kernels/zgemm/gemm_utils.cuh
@@ -355,6 +355,14 @@ __device__ __forceinline__ static void reduce_add_pred(float *addr, float val, b
                  "f"(val));
 }
 
+__device__ __forceinline__ static void reduce_add_pred(int *addr, int val, bool pred) {
+    asm volatile("{ .reg .pred storepred; setp.ne.b32 storepred, %0, 0;"
+                 "@storepred red.relaxed.gpu.global.add.s32 [%1], %2;"
+                 "}" ::"r"((int)pred),
+                 "l"(addr),
+                 "r"(val));
+}
+
 template<int cnt, typename F>
 __device__ __forceinline__ static void unrolled_loop(F &&lambda) {
     auto call = [&]<int... Is>(std::integer_sequence<int, Is...>) { (lambda.template operator()<Is>(), ...); };

--- a/src/kernels/zgemm/gemm_w4a4.cuh
+++ b/src/kernels/zgemm/gemm_w4a4.cuh
@@ -1109,7 +1109,7 @@ public:
             packed_act_t *output;
             oscales_t *oscales;
             const packed_fpsum_t *lora_wgt_down;
-            float *lora_act;
+            int *lora_act;
 
             int lora_rank;
 

--- a/src/kernels/zgemm/gemm_w4a4_launch_impl.cuh
+++ b/src/kernels/zgemm/gemm_w4a4_launch_impl.cuh
@@ -230,7 +230,7 @@ void GEMM_W4A4_Launch<GEMMConfig_W4A4_FP16, false>::gemm_w4a4(
                                                                 NextEpilogue,
                                                                 typename GEMM::EpilogueNop>;
             return launch_bias.template operator()<Epilogue>({typename LoraUp::EpilogueLoraUp::Arguments{
-                                                                  .lora_act    = lora_act_in.data_ptr<float>(),
+                                                                  .lora_act    = lora_act_in.data_ptr<int>(),
                                                                   .lora_wgt_up = lora_up.data_ptr<packed_fpsum_t>(),
                                                                   .rank        = rank_up,
                                                                   .scales      = scales,
@@ -260,7 +260,7 @@ void GEMM_W4A4_Launch<GEMMConfig_W4A4_FP16, false>::gemm_w4a4(
                                                             NextEpilogue,
                                                             typename GEMM::EpilogueNop>;
         return launch_bias.template operator()<Epilogue>({typename LoraUp::EpilogueLoraUp::Arguments{
-                                                              .lora_act    = lora_act_in.data_ptr<float>(),
+                                                              .lora_act    = lora_act_in.data_ptr<int>(),
                                                               .lora_wgt_up = lora_up.data_ptr<packed_fpsum_t>(),
                                                               .rank        = rank_up,
                                                               .scales      = scales,
@@ -269,7 +269,7 @@ void GEMM_W4A4_Launch<GEMMConfig_W4A4_FP16, false>::gemm_w4a4(
                                                           midArgs,
                                                           typename LoraDown::EpilogueLoraDown::Arguments{
                                                               .lora_wgt_down = lora_down.data_ptr<packed_fpsum_t>(),
-                                                              .lora_act      = lora_act_out.data_ptr<float>(),
+                                                              .lora_act      = lora_act_out.data_ptr<int>(),
                                                               .rank          = rank_down,
                                                               .alwaysfalse   = false,
                                                           },
@@ -507,7 +507,7 @@ void GEMM_W4A4_Launch<Config, USE_FP4>::quantize_w4a4_act_fuse_lora(Tensor input
                 .output        = output.data_ptr<packed_act_t>(),
                 .oscales       = oscales.data_ptr<typename kernel::oscales_t>(),
                 .lora_wgt_down = lora_down.data_ptr<packed_fpsum_t>(),
-                .lora_act      = lora_act_out.data_ptr<float>(),
+                .lora_act      = lora_act_out.data_ptr<int>(),
                 .lora_rank     = rank,
                 .M             = M,
                 .N             = N,


### PR DESCRIPTION
**Motivation**

  Floating-point atomic add operations (atomicAdd / red.add.f32) on GPUs are non-deterministic due to the unpredictable order of thread execution, causing slight variations in results. This non-deterministic behavior is problematic for scenarios requiring strict reproducibility, such as debugging, testing, and scientific computing.

  This PR enables deterministic LoRA activation reduction by replacing floating-point reduction with fixed-point integer arithmetic, ensuring identical outputs for the same inputs across runs.

 There also are some issues refer to this feature:  https://github.com/nunchaku-tech/nunchaku/issues/546 https://github.com/nunchaku-tech/nunchaku/issues/229 https://github.com/nunchaku-tech/nunchaku/issues/294
https://github.com/spooknik/nunchaku-chroma/issues/6
  **Modifications**

  - gemm_utils.cuh: Added an int overload of reduce_add_pred using red.relaxed.gpu.global.add.s32 for deterministic integer atomic addition
  - lora.cuh:
    - Changed lora_act data type from float* to int*
    - Implemented 16-bit fractional precision (FRAC_BITS = 16) fixed-point representation in reduce_lora_act, scaling float values to integers before reduction
    - In apply_lora_up, dequantized fixed-point integers back to floats with the inverse scale factor fused into scales to avoid extra computation overhead
  - gemm_w4a4.cuh / gemm_w4a4_launch_impl.cuh: Updated relevant type declarations and pointer casts