### PR TITLE
fix: add torch 2.7 and 2.8 for windows

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -121,7 +121,7 @@ jobs:
     strategy:
       matrix:
         python: ["3.10", "3.11", "3.12", "3.13"]
-        torch: ["2.9", "pre"]
+        torch: ["2.7", "2.8", "2.9", "pre"]
     steps:
       - name: Checkout to the tag
         uses: actions/checkout@v4

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -106,7 +106,7 @@ jobs:
     strategy:
       matrix:
         python: ["3.10", "3.11", "3.12", "3.13"]
-        torch: ["2.9", "pre"]
+        torch: ["2.7", "2.8", "2.9", "pre"]
     steps:
       - name: Checkout to the tag
         uses: actions/checkout@v4


### PR DESCRIPTION
<!-- Thank you for your contribution—we truly appreciate it! To help us review your pull request efficiently, please follow the guidelines below. If anything is unclear, feel free to open the PR and ask for clarification. You can also refer to our [contribution guide](./docs/contribution_guide.md) for more details. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
This PR adds PyTorch 2.7 and 2.8 to the Windows build matrix strategy.

I noticed that Torch 2.7 and 2.8 were simply excluded from the Windows builds.

Was this intentional for a specific reason? If not, this change fixes the missing wheels to ensure parity with the Linux builds.

## Modifications

<!-- Describe the changes made in this PR. -->
- Updated the `windows-wheels` job matrix in `nightly-build.yaml` (and/or `release-build.yaml`) to include `2.7` and `2.8` in the `torch` list.

## Checklist

- [x] Code is formatted using Pre-Commit hooks.
- [ ] Relevant unit tests are added in the [`tests`](../tests) directory following the guidance in [`Contribution Guide`](https://nunchaku.tech/docs/nunchaku/developer/contribution_guide.html).
- [ ] [Documentation](../docs/source) and example scripts in [`examples`](../examples) are updated if necessary.
- [ ] Throughput/latency benchmarks and quality evaluations are included where applicable.
- [ ] **For reviewers:** If you're only helping merge the main branch and haven't contributed code to this PR, please remove yourself as a co-author when merging.
- [x] Please feel free to join our [Slack](https://join.slack.com/t/nunchaku/shared_invite/zt-3170agzoz-NgZzWaTrEj~n2KEV3Hpl5Q), [Discord](https://discord.gg/Wk6PnwX9Sm) or [WeChat](https://huggingface.co/datasets/nunchaku-tech/cdn/blob/main/nunchaku/assets/wechat.jpg) to discuss your PR.