### PR TITLE
[Qwen] Validate encoder_hidden_states for text sequence length

### DIFF
--- a/nunchaku/models/transformers/transformer_qwenimage.py
+++ b/nunchaku/models/transformers/transformer_qwenimage.py
@@ -514,7 +514,10 @@ class NunchakuQwenImageTransformer2DModel(QwenImageTransformer2DModel, NunchakuM
             else self.time_text_embed(timestep, guidance, hidden_states)
         )
 
-        image_rotary_emb = self.pos_embed(img_shapes, txt_seq_lens, device=hidden_states.device)
+        text_seq_len = encoder_hidden_states.shape[1] if encoder_hidden_states is not None else None
+        if text_seq_len is None:
+            raise ValueError("encoder_hidden_states must be provided to compute text sequence length")
+        image_rotary_emb = self.pos_embed(img_shapes, max_txt_seq_len=text_seq_len, device=hidden_states.device)
 
         compute_stream = torch.cuda.current_stream()
         if self.offload:


### PR DESCRIPTION
Added validation for encoder_hidden_states to ensure text sequence length is computed correctly.

fixes #884

<!-- Thank you for your contribution—we truly appreciate it! To help us review your pull request efficiently, please follow the guidelines below. If anything is unclear, feel free to open the PR and ask for clarification. You can also refer to our [contribution guide](./docs/contribution_guide.md) for more details. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Code is formatted using Pre-Commit hooks.
- [ ] Relevant unit tests are added in the [`tests`](../tests) directory following the guidance in [`Contribution Guide`](https://nunchaku.tech/docs/nunchaku/developer/contribution_guide.html).
- [ ] [Documentation](../docs/source) and example scripts in [`examples`](../examples) are updated if necessary.
- [ ] Throughput/latency benchmarks and quality evaluations are included where applicable.
- [ ] **For reviewers:** If you're only helping merge the main branch and haven't contributed code to this PR, please remove yourself as a co-author when merging.
- [ ] Please feel free to join our [Slack](https://join.slack.com/t/nunchaku/shared_invite/zt-3170agzoz-NgZzWaTrEj~n2KEV3Hpl5Q), [Discord](https://discord.gg/Wk6PnwX9Sm) or [WeChat](https://huggingface.co/datasets/nunchaku-tech/cdn/blob/main/nunchaku/assets/wechat.jpg) to discuss your PR.
