### PR TITLE
feat(lora): implement fast LoRA switching for instant variant switching

### DIFF
--- a/examples/fast_lora_switching.py
+++ b/examples/fast_lora_switching.py
@@ -1,0 +1,170 @@
+"""
+Example: Fast LoRA Switching
+
+This example demonstrates how to use the fast LoRA switching feature
+for real-time interactive applications.
+
+使用方法:
+    python examples/fast_lora_switching.py
+
+输出:
+    - test_results/fast_lora_switching/ 目录下的图片
+    - 终端输出性能对比
+"""
+
+import os
+import time
+
+import torch
+from diffusers import FluxPipeline
+
+from nunchaku import NunchakuFluxTransformer2dModel
+from nunchaku.utils import get_precision
+
+
+def main():
+    precision = get_precision()
+    print(f"Using precision: {precision}")
+    print(f"GPU: {torch.cuda.get_device_name(0)}")
+
+    # Create output directory
+    output_dir = "test_results/fast_lora_switching"
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Load model
+    print("\nLoading model...")
+    transformer = NunchakuFluxTransformer2dModel.from_pretrained(
+        f"nunchaku-tech/nunchaku-flux.1-krea-dev/svdq-{precision}_r32-flux.1-krea-dev.safetensors"
+    )
+    pipeline = FluxPipeline.from_pretrained(
+        "black-forest-labs/FLUX.1-dev",
+        transformer=transformer,
+        torch_dtype=torch.bfloat16,
+    ).to("cuda")
+
+    # Define LoRAs to use
+    loras = {
+        "base": None,
+        "anime": "XLabs-AI/flux-lora-collection/anime_lora.safetensors",
+        "realism": "XLabs-AI/flux-lora-collection/realism_lora.safetensors",
+    }
+
+    # Preload LoRA variants
+    print("\nPreloading LoRA variants...")
+    t0 = time.perf_counter()
+    transformer.preload_loras(loras)
+    preload_time = time.perf_counter() - t0
+    print(f"Preload time: {preload_time * 1000:.1f}ms")
+    print(f"Available variants: {transformer.list_preloaded_loras()}")
+
+    # Benchmark fast switching
+    print("\n" + "=" * 60)
+    print("Benchmarking Fast LoRA Switching")
+    print("=" * 60)
+    n_switches = 20
+    lora_names = list(loras.keys())
+
+    # Warm up
+    for name in lora_names:
+        transformer.switch_lora(name)
+    torch.cuda.synchronize()
+
+    # Benchmark
+    switch_times = []
+    for i in range(n_switches):
+        name = lora_names[i % len(lora_names)]
+        t0 = time.perf_counter()
+        transformer.switch_lora(name)
+        torch.cuda.synchronize()
+        switch_times.append(time.perf_counter() - t0)
+
+    avg_switch_time = sum(switch_times) / len(switch_times)
+    print(
+        f"Fast switch - Avg: {avg_switch_time * 1000:.2f}ms, "
+        f"Min: {min(switch_times) * 1000:.2f}ms, "
+        f"Max: {max(switch_times) * 1000:.2f}ms"
+    )
+
+    # Benchmark traditional switching
+    print("\n" + "=" * 60)
+    print("Benchmarking Traditional LoRA Switching")
+    print("=" * 60)
+
+    # Reset first
+    transformer.reset_lora()
+
+    traditional_times = []
+    for i in range(6):  # 2 cycles through 3 LoRAs
+        name = lora_names[i % len(lora_names)]
+        lora_path = loras[name]
+
+        transformer.reset_lora()
+        torch.cuda.synchronize()
+
+        t0 = time.perf_counter()
+        if lora_path is not None:
+            transformer.update_lora_params(lora_path)
+        torch.cuda.synchronize()
+        traditional_times.append(time.perf_counter() - t0)
+
+    avg_traditional_time = sum(traditional_times) / len(traditional_times)
+    print(
+        f"Traditional switch - Avg: {avg_traditional_time * 1000:.2f}ms, "
+        f"Min: {min(traditional_times) * 1000:.2f}ms, "
+        f"Max: {max(traditional_times) * 1000:.2f}ms"
+    )
+
+    # Summary
+    print("\n" + "=" * 60)
+    print("Summary")
+    print("=" * 60)
+    speedup = avg_traditional_time / avg_switch_time
+    print(f"Fast switching:        {avg_switch_time * 1000:.2f}ms")
+    print(f"Traditional switching: {avg_traditional_time * 1000:.2f}ms")
+    print(f"Speedup:               {speedup:.1f}x faster")
+    print(f"Preload cost:          {preload_time * 1000:.1f}ms (one-time)")
+    break_even = preload_time / (avg_traditional_time - avg_switch_time)
+    print(f"Break-even:            {break_even:.1f} switches")
+
+    # Generate images with each LoRA
+    print("\n" + "=" * 60)
+    print("Generating Images")
+    print("=" * 60)
+
+    prompts = {
+        "base": "a beautiful sunset over mountains, highly detailed, 8k",
+        "anime": "a beautiful sunset over mountains, anime style, studio ghibli",
+        "realism": "a beautiful sunset over mountains, photorealistic, DSLR photo",
+    }
+
+    # Reset to use fast switching
+    transformer.reset_lora()
+    transformer.preload_loras(loras)
+
+    for name in lora_names:
+        print(f"\nGenerating with '{name}' LoRA...")
+        transformer.switch_lora(name)
+
+        t0 = time.perf_counter()
+        image = pipeline(
+            prompts[name],
+            num_inference_steps=20,
+            guidance_scale=3.5,
+            generator=torch.Generator("cuda").manual_seed(42),
+        ).images[0]
+        gen_time = time.perf_counter() - t0
+
+        output_path = os.path.join(output_dir, f"{name}.png")
+        image.save(output_path)
+        print(f"  Saved: {output_path} ({gen_time:.2f}s)")
+
+    print("\n" + "=" * 60)
+    print(f"All images saved to: {output_dir}/")
+    print("=" * 60)
+
+    # Cleanup
+    transformer.clear_preloaded_loras()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/flux/test_fast_lora_switching.py
+++ b/tests/flux/test_fast_lora_switching.py
@@ -1,0 +1,226 @@
+"""Tests for fast LoRA switching functionality."""
+
+import gc
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+
+# Mock the nunchaku._C module before importing any nunchaku modules
+# This allows unit tests to run without the C extension
+@pytest.fixture(autouse=True)
+def mock_c_extension():
+    """Mock the C extension module to allow testing without GPU."""
+    mock_c = MagicMock()
+    mock_c.QuantizedFluxModel = MagicMock
+    mock_c.utils = MagicMock()
+
+    # Store original modules to restore later
+    original_modules = {}
+    modules_to_mock = ["nunchaku._C", "nunchaku._C.ops", "nunchaku._C.utils"]
+
+    for mod_name in modules_to_mock:
+        if mod_name in sys.modules:
+            original_modules[mod_name] = sys.modules[mod_name]
+        sys.modules[mod_name] = mock_c
+
+    yield
+
+    # Restore original modules
+    for mod_name in modules_to_mock:
+        if mod_name in original_modules:
+            sys.modules[mod_name] = original_modules[mod_name]
+        elif mod_name in sys.modules:
+            del sys.modules[mod_name]
+
+
+class TestFastLoRASwitchingUnit:
+    """Unit tests for fast LoRA switching (no GPU required)."""
+
+    def test_preload_loras_initializes_variants(self, mock_c_extension):
+        """Test that preload_loras populates the variant dictionaries."""
+        from nunchaku.models.transformers.transformer_flux import NunchakuFluxTransformer2dModel
+
+        # Create a minimal mock transformer
+        with patch.object(NunchakuFluxTransformer2dModel, "__init__", lambda self: None):
+            transformer = NunchakuFluxTransformer2dModel()
+            transformer._lora_variants = {}
+            transformer._lora_variant_unquantized = {}
+            transformer._lora_variant_vectors = {}
+            transformer._active_lora_variant = None
+            transformer._quantized_part_sd = {"lora_down": torch.zeros(1), "lora_up": torch.zeros(1)}
+            transformer._unquantized_part_sd = {}
+
+            # Mock the parameters() to return a tensor on CPU for device detection
+            transformer.parameters = MagicMock(return_value=iter([torch.zeros(1)]))
+
+            # Test preloading None (base model)
+            transformer.preload_loras({"none": None})
+
+            assert "none" in transformer._lora_variants
+            assert "none" in transformer._lora_variant_unquantized
+            assert "none" in transformer._lora_variant_vectors
+
+    def test_list_preloaded_loras(self, mock_c_extension):
+        """Test that list_preloaded_loras returns correct names."""
+        from nunchaku.models.transformers.transformer_flux import NunchakuFluxTransformer2dModel
+
+        with patch.object(NunchakuFluxTransformer2dModel, "__init__", lambda self: None):
+            transformer = NunchakuFluxTransformer2dModel()
+            transformer._lora_variants = {"a": {}, "b": {}, "c": {}}
+
+            result = transformer.list_preloaded_loras()
+            assert set(result) == {"a", "b", "c"}
+
+    def test_get_active_lora_returns_none_initially(self, mock_c_extension):
+        """Test that get_active_lora returns None when no variant is active."""
+        from nunchaku.models.transformers.transformer_flux import NunchakuFluxTransformer2dModel
+
+        with patch.object(NunchakuFluxTransformer2dModel, "__init__", lambda self: None):
+            transformer = NunchakuFluxTransformer2dModel()
+            transformer._active_lora_variant = None
+
+            assert transformer.get_active_lora() is None
+
+    def test_switch_lora_raises_on_unknown_variant(self, mock_c_extension):
+        """Test that switch_lora raises KeyError for unknown variants."""
+        from nunchaku.models.transformers.transformer_flux import NunchakuFluxTransformer2dModel
+
+        with patch.object(NunchakuFluxTransformer2dModel, "__init__", lambda self: None):
+            transformer = NunchakuFluxTransformer2dModel()
+            transformer._lora_variants = {"known": {}}
+
+            with pytest.raises(KeyError, match="unknown"):
+                transformer.switch_lora("unknown")
+
+    def test_unload_lora_variant_raises_on_active(self, mock_c_extension):
+        """Test that unload_lora_variant raises when trying to unload active variant."""
+        from nunchaku.models.transformers.transformer_flux import NunchakuFluxTransformer2dModel
+
+        with patch.object(NunchakuFluxTransformer2dModel, "__init__", lambda self: None):
+            transformer = NunchakuFluxTransformer2dModel()
+            transformer._lora_variants = {"active": {}}
+            transformer._lora_variant_unquantized = {"active": {}}
+            transformer._lora_variant_vectors = {"active": {}}
+            transformer._active_lora_variant = "active"
+
+            with pytest.raises(ValueError, match="Cannot unload active"):
+                transformer.unload_lora_variant("active")
+
+    def test_unload_lora_variant_removes_variant(self, mock_c_extension):
+        """Test that unload_lora_variant removes the variant."""
+        from nunchaku.models.transformers.transformer_flux import NunchakuFluxTransformer2dModel
+
+        with patch.object(NunchakuFluxTransformer2dModel, "__init__", lambda self: None):
+            transformer = NunchakuFluxTransformer2dModel()
+            transformer._lora_variants = {"a": {}, "b": {}}
+            transformer._lora_variant_unquantized = {"a": {}, "b": {}}
+            transformer._lora_variant_vectors = {"a": {}, "b": {}}
+            transformer._active_lora_variant = "a"
+
+            transformer.unload_lora_variant("b")
+
+            assert "b" not in transformer._lora_variants
+            assert "a" in transformer._lora_variants
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+class TestFastLoRASwitchingIntegration:
+    """Integration tests for fast LoRA switching (requires GPU)."""
+
+    def test_preload_and_switch_loras(self):
+        """Test full preload and switch workflow."""
+        from nunchaku import NunchakuFluxTransformer2dModel
+        from nunchaku.utils import get_precision
+
+        precision = get_precision()
+        transformer = NunchakuFluxTransformer2dModel.from_pretrained(
+            f"mit-han-lab/nunchaku-flux.1-dev/svdq-{precision}_r32-flux.1-dev.safetensors", offload=True
+        )
+
+        # Preload variants
+        transformer.preload_loras(
+            {
+                "none": None,
+                "turbo": "alimama-creative/FLUX.1-Turbo-Alpha/diffusion_pytorch_model.safetensors",
+            }
+        )
+
+        # Verify preloaded
+        assert set(transformer.list_preloaded_loras()) == {"none", "turbo"}
+        assert transformer.get_active_lora() is None
+
+        # Switch to turbo
+        transformer.switch_lora("turbo")
+        assert transformer.get_active_lora() == "turbo"
+
+        # Switch to none
+        transformer.switch_lora("none")
+        assert transformer.get_active_lora() == "none"
+
+        # Clean up
+        transformer.clear_preloaded_loras()
+        assert len(transformer.list_preloaded_loras()) == 0
+
+        # Cleanup
+        del transformer
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    def test_switch_lora_produces_correct_output(self):
+        """Test that switching LoRAs produces different outputs."""
+        import os
+
+        from diffusers import FluxPipeline
+
+        from nunchaku import NunchakuFluxTransformer2dModel
+        from nunchaku.utils import get_precision
+        from tests.utils import compute_lpips
+
+        precision = get_precision()
+        transformer = NunchakuFluxTransformer2dModel.from_pretrained(
+            f"mit-han-lab/nunchaku-flux.1-dev/svdq-{precision}_r32-flux.1-dev.safetensors", offload=True
+        )
+        pipeline = FluxPipeline.from_pretrained(
+            "black-forest-labs/FLUX.1-dev", transformer=transformer, torch_dtype=torch.bfloat16
+        )
+        pipeline.enable_sequential_cpu_offload()
+
+        # Preload variants
+        transformer.preload_loras(
+            {
+                "none": None,
+                "turbo": "alimama-creative/FLUX.1-Turbo-Alpha/diffusion_pytorch_model.safetensors",
+            }
+        )
+
+        save_dir = os.path.join("test_results", "fast_lora_switching")
+        os.makedirs(save_dir, exist_ok=True)
+
+        prompt = "a beautiful sunset over mountains"
+        generator = torch.Generator().manual_seed(42)
+
+        # Generate with no LoRA
+        transformer.switch_lora("none")
+        image_none = pipeline(prompt, num_inference_steps=8, guidance_scale=3.5, generator=generator).images[0]
+        image_none.save(os.path.join(save_dir, "none.png"))
+
+        # Generate with turbo LoRA
+        generator = torch.Generator().manual_seed(42)
+        transformer.switch_lora("turbo", strength=1.0)
+        image_turbo = pipeline(prompt, num_inference_steps=8, guidance_scale=3.5, generator=generator).images[0]
+        image_turbo.save(os.path.join(save_dir, "turbo.png"))
+
+        # Verify outputs are different
+        lpips = compute_lpips(os.path.join(save_dir, "none.png"), os.path.join(save_dir, "turbo.png"))
+        print(f"LPIPS between none and turbo: {lpips}")
+        assert lpips > 0.05, "LoRA should produce different output"
+
+        # Cleanup
+        transformer.clear_preloaded_loras()
+        del pipeline
+        del transformer
+        gc.collect()
+        torch.cuda.empty_cache()

--- a/tests/flux/test_fast_lora_switching_benchmark.py
+++ b/tests/flux/test_fast_lora_switching_benchmark.py
@@ -1,0 +1,437 @@
+"""Benchmark tests for fast LoRA switching performance.
+
+This module tests the performance difference between traditional LoRA switching
+(reset_lora + update_lora_params) and fast LoRA switching (preload_loras + switch_lora).
+
+Run with: pytest tests/flux/test_fast_lora_switching_benchmark.py -v -s
+"""
+
+import gc
+import logging
+import time
+from dataclasses import dataclass
+
+import pytest
+import torch
+
+from nunchaku import NunchakuFluxTransformer2dModel
+from nunchaku.utils import get_precision
+
+_LOGGER = logging.getLogger(__name__)
+
+# Expected speedup ratios for different GPUs
+_EXPECTED_SPEEDUPS = {
+    "NVIDIA GeForce RTX 3090": 30.0,
+    "NVIDIA GeForce RTX 4090": 40.0,
+    "NVIDIA GeForce RTX 5090": 40.0,
+}
+
+
+@dataclass
+class TimingResult:
+    """Timing result for a single LoRA switch + forward pass."""
+
+    lora_name: str
+    switch_time_ms: float
+    forward_time_ms: float
+
+    @property
+    def total_time_ms(self) -> float:
+        return self.switch_time_ms + self.forward_time_ms
+
+
+def create_dummy_inputs(device: str = "cuda", dtype: torch.dtype = torch.bfloat16) -> dict:
+    """Create dummy inputs for transformer forward pass."""
+    return {
+        "hidden_states": torch.randn(1, 256, 64, device=device, dtype=dtype),
+        "encoder_hidden_states": torch.randn(1, 512, 4096, device=device, dtype=dtype),
+        "pooled_projections": torch.randn(1, 768, device=device, dtype=dtype),
+        "timestep": torch.tensor([500.0], device=device, dtype=dtype),
+        "img_ids": torch.zeros(256, 3, device=device, dtype=dtype),
+        "txt_ids": torch.zeros(512, 3, device=device, dtype=dtype),
+        "guidance": torch.tensor([3.5], device=device, dtype=dtype),
+        "return_dict": False,
+    }
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+class TestFastLoRASwitchingBenchmark:
+    """Benchmark tests for fast LoRA switching."""
+
+    @pytest.fixture(autouse=True)
+    def setup_and_teardown(self):
+        """Clean up GPU memory before and after each test."""
+        gc.collect()
+        torch.cuda.empty_cache()
+        yield
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    def test_switch_speedup(self):
+        """Test that fast LoRA switching is significantly faster than traditional method."""
+        precision = get_precision()
+        device_name = torch.cuda.get_device_name(0)
+        expected_speedup = _EXPECTED_SPEEDUPS.get(device_name, 20.0)
+
+        _LOGGER.info(f"GPU: {device_name}, Precision: {precision}")
+
+        # Load model
+        transformer = NunchakuFluxTransformer2dModel.from_pretrained(
+            f"nunchaku-tech/nunchaku-flux.1-krea-dev/svdq-{precision}_r32-flux.1-krea-dev.safetensors"
+        )
+
+        # Get LoRA paths
+        from huggingface_hub import hf_hub_download
+
+        lora_anime = hf_hub_download("XLabs-AI/flux-lora-collection", "anime_lora.safetensors")
+        lora_realism = hf_hub_download("XLabs-AI/flux-lora-collection", "realism_lora.safetensors")
+
+        loras = {"anime": lora_anime, "realism": lora_realism}
+        lora_names = list(loras.keys())
+        num_iters = 6
+
+        # Warm up
+        inputs = create_dummy_inputs()
+        for _ in range(3):
+            with torch.no_grad():
+                _ = transformer(**inputs)
+        torch.cuda.synchronize()
+
+        # Benchmark traditional method
+        transformer.reset_lora()
+        traditional_switch_times = []
+
+        for i in range(num_iters):
+            lora_name = lora_names[i % 2]
+            lora_path = loras[lora_name]
+
+            transformer.reset_lora()
+            torch.cuda.synchronize()
+
+            start = time.perf_counter()
+            transformer.update_lora_params(lora_path)
+            torch.cuda.synchronize()
+            traditional_switch_times.append((time.perf_counter() - start) * 1000)
+
+        traditional_avg = sum(traditional_switch_times) / len(traditional_switch_times)
+        _LOGGER.info(f"Traditional switch avg: {traditional_avg:.2f}ms")
+
+        # Reset for fast method
+        transformer.reset_lora()
+        gc.collect()
+        torch.cuda.empty_cache()
+
+        # Preload LoRAs
+        preload_start = time.perf_counter()
+        transformer.preload_loras(loras)
+        torch.cuda.synchronize()
+        preload_time = (time.perf_counter() - preload_start) * 1000
+        _LOGGER.info(f"Preload time: {preload_time:.2f}ms")
+
+        # Benchmark fast method
+        # Warm up
+        for name in lora_names:
+            transformer.switch_lora(name)
+        torch.cuda.synchronize()
+
+        fast_switch_times = []
+        for i in range(num_iters):
+            lora_name = lora_names[i % 2]
+
+            start = time.perf_counter()
+            transformer.switch_lora(lora_name)
+            torch.cuda.synchronize()
+            fast_switch_times.append((time.perf_counter() - start) * 1000)
+
+        fast_avg = sum(fast_switch_times) / len(fast_switch_times)
+        _LOGGER.info(f"Fast switch avg: {fast_avg:.2f}ms")
+
+        speedup = traditional_avg / fast_avg
+        _LOGGER.info(f"Speedup: {speedup:.1f}x")
+
+        # Cleanup
+        transformer.clear_preloaded_loras()
+        del transformer
+
+        assert speedup >= expected_speedup * 0.5, (
+            f"Fast switching should be at least {expected_speedup * 0.5:.1f}x faster, " f"but got {speedup:.1f}x"
+        )
+
+    def test_forward_pass_consistency(self):
+        """Test that forward pass time is consistent between switching methods."""
+        precision = get_precision()
+
+        transformer = NunchakuFluxTransformer2dModel.from_pretrained(
+            f"nunchaku-tech/nunchaku-flux.1-krea-dev/svdq-{precision}_r32-flux.1-krea-dev.safetensors"
+        )
+
+        from huggingface_hub import hf_hub_download
+
+        lora_path = hf_hub_download("XLabs-AI/flux-lora-collection", "anime_lora.safetensors")
+        inputs = create_dummy_inputs()
+
+        # Warm up
+        for _ in range(3):
+            with torch.no_grad():
+                _ = transformer(**inputs)
+        torch.cuda.synchronize()
+
+        # Test traditional method forward time
+        transformer.update_lora_params(lora_path)
+        torch.cuda.synchronize()
+
+        traditional_times = []
+        for _ in range(5):
+            start = time.perf_counter()
+            with torch.no_grad():
+                _ = transformer(**inputs)
+            torch.cuda.synchronize()
+            traditional_times.append((time.perf_counter() - start) * 1000)
+
+        traditional_avg = sum(traditional_times) / len(traditional_times)
+
+        # Reset and use fast method
+        transformer.reset_lora()
+        transformer.preload_loras({"anime": lora_path})
+        transformer.switch_lora("anime")
+        torch.cuda.synchronize()
+
+        fast_times = []
+        for _ in range(5):
+            start = time.perf_counter()
+            with torch.no_grad():
+                _ = transformer(**inputs)
+            torch.cuda.synchronize()
+            fast_times.append((time.perf_counter() - start) * 1000)
+
+        fast_avg = sum(fast_times) / len(fast_times)
+
+        _LOGGER.info(f"Traditional forward avg: {traditional_avg:.2f}ms")
+        _LOGGER.info(f"Fast forward avg: {fast_avg:.2f}ms")
+
+        # Forward times should be within 20% of each other
+        ratio = max(traditional_avg, fast_avg) / min(traditional_avg, fast_avg)
+        assert ratio < 1.2, f"Forward times should be similar, but ratio is {ratio:.2f}"
+
+        # Cleanup
+        transformer.clear_preloaded_loras()
+        del transformer
+
+    def test_inference_with_switching(self):
+        """Test complete inference workflow with LoRA switching."""
+        precision = get_precision()
+
+        transformer = NunchakuFluxTransformer2dModel.from_pretrained(
+            f"nunchaku-tech/nunchaku-flux.1-krea-dev/svdq-{precision}_r32-flux.1-krea-dev.safetensors"
+        )
+
+        from huggingface_hub import hf_hub_download
+
+        lora_anime = hf_hub_download("XLabs-AI/flux-lora-collection", "anime_lora.safetensors")
+        lora_realism = hf_hub_download("XLabs-AI/flux-lora-collection", "realism_lora.safetensors")
+
+        loras = {"anime": lora_anime, "realism": lora_realism, "base": None}
+        inputs = create_dummy_inputs()
+        num_iters = 9  # 3 cycles through 3 LoRAs
+
+        # Warm up
+        for _ in range(3):
+            with torch.no_grad():
+                _ = transformer(**inputs)
+        torch.cuda.synchronize()
+
+        # Traditional method
+        transformer.reset_lora()
+        traditional_results: list[TimingResult] = []
+
+        lora_names = list(loras.keys())
+        for i in range(num_iters):
+            lora_name = lora_names[i % 3]
+            lora_path = loras[lora_name]
+
+            transformer.reset_lora()
+            torch.cuda.synchronize()
+
+            switch_start = time.perf_counter()
+            if lora_path is not None:
+                transformer.update_lora_params(lora_path)
+            torch.cuda.synchronize()
+            switch_time = (time.perf_counter() - switch_start) * 1000
+
+            forward_start = time.perf_counter()
+            with torch.no_grad():
+                _ = transformer(**inputs)
+            torch.cuda.synchronize()
+            forward_time = (time.perf_counter() - forward_start) * 1000
+
+            traditional_results.append(TimingResult(lora_name, switch_time, forward_time))
+
+        # Fast method
+        transformer.reset_lora()
+        gc.collect()
+        torch.cuda.empty_cache()
+
+        preload_start = time.perf_counter()
+        transformer.preload_loras(loras)
+        torch.cuda.synchronize()
+        preload_time = (time.perf_counter() - preload_start) * 1000
+
+        # Warm up fast switches
+        for name in lora_names:
+            transformer.switch_lora(name)
+        torch.cuda.synchronize()
+
+        fast_results: list[TimingResult] = []
+
+        for i in range(num_iters):
+            lora_name = lora_names[i % 3]
+
+            switch_start = time.perf_counter()
+            transformer.switch_lora(lora_name)
+            torch.cuda.synchronize()
+            switch_time = (time.perf_counter() - switch_start) * 1000
+
+            forward_start = time.perf_counter()
+            with torch.no_grad():
+                _ = transformer(**inputs)
+            torch.cuda.synchronize()
+            forward_time = (time.perf_counter() - forward_start) * 1000
+
+            fast_results.append(TimingResult(lora_name, switch_time, forward_time))
+
+        # Print comparison table
+        _LOGGER.info("\nPer-iteration comparison:")
+        _LOGGER.info(f"{'#':<3} {'LoRA':<10} {'Trad Switch':>12} {'Fast Switch':>12} {'Saved':>10}")
+        _LOGGER.info("-" * 55)
+        for i, (t, f) in enumerate(zip(traditional_results, fast_results)):
+            saved = t.switch_time_ms - f.switch_time_ms
+            _LOGGER.info(
+                f"{i+1:<3} {t.lora_name:<10} {t.switch_time_ms:>10.1f}ms {f.switch_time_ms:>10.1f}ms {saved:>8.1f}ms"
+            )
+
+        # Calculate totals
+        trad_total_switch = sum(r.switch_time_ms for r in traditional_results)
+        trad_total_forward = sum(r.forward_time_ms for r in traditional_results)
+        fast_total_switch = sum(r.switch_time_ms for r in fast_results)
+        fast_total_forward = sum(r.forward_time_ms for r in fast_results)
+
+        _LOGGER.info(f"\nSummary ({num_iters} iterations):")
+        _LOGGER.info(f"  Traditional - switch: {trad_total_switch:.1f}ms, forward: {trad_total_forward:.1f}ms")
+        _LOGGER.info(f"  Fast        - switch: {fast_total_switch:.1f}ms, forward: {fast_total_forward:.1f}ms")
+        _LOGGER.info(f"  Preload cost: {preload_time:.1f}ms")
+        _LOGGER.info(f"  Time saved (excl preload): {trad_total_switch - fast_total_switch:.1f}ms")
+        _LOGGER.info(f"  Time saved (incl preload): {trad_total_switch - fast_total_switch - preload_time:.1f}ms")
+
+        # Assertions
+        assert fast_total_switch < trad_total_switch, "Fast method should have lower total switch time"
+        assert (trad_total_switch - fast_total_switch) > preload_time, (
+            f"Switch time savings ({trad_total_switch - fast_total_switch:.1f}ms) should exceed "
+            f"preload cost ({preload_time:.1f}ms) for {num_iters} iterations"
+        )
+
+        # Cleanup
+        transformer.clear_preloaded_loras()
+        del transformer
+
+    def test_output_consistency(self):
+        """Test that fast switching produces identical output as traditional switching."""
+        precision = get_precision()
+
+        transformer = NunchakuFluxTransformer2dModel.from_pretrained(
+            f"nunchaku-tech/nunchaku-flux.1-krea-dev/svdq-{precision}_r32-flux.1-krea-dev.safetensors"
+        )
+
+        from huggingface_hub import hf_hub_download
+
+        lora_path = hf_hub_download("XLabs-AI/flux-lora-collection", "anime_lora.safetensors")
+
+        inputs = create_dummy_inputs()
+
+        # Traditional method output
+        transformer.update_lora_params(lora_path)
+        torch.cuda.synchronize()
+
+        with torch.no_grad():
+            output_traditional = transformer(**inputs)
+        if isinstance(output_traditional, tuple):
+            output_traditional = output_traditional[0]
+        output_traditional = output_traditional.clone()
+
+        # Reset and use fast method
+        transformer.reset_lora()
+        transformer.preload_loras({"anime": lora_path})
+        transformer.switch_lora("anime")
+        torch.cuda.synchronize()
+
+        with torch.no_grad():
+            output_fast = transformer(**inputs)
+        if isinstance(output_fast, tuple):
+            output_fast = output_fast[0]
+
+        # Compare outputs
+        max_diff = (output_traditional - output_fast).abs().max().item()
+        mean_diff = (output_traditional - output_fast).abs().mean().item()
+
+        _LOGGER.info(f"Output comparison - max diff: {max_diff:.6f}, mean diff: {mean_diff:.6f}")
+
+        # Outputs should be nearly identical (allow small floating point differences)
+        assert max_diff < 1e-4, f"Outputs differ too much: max_diff={max_diff}"
+        assert mean_diff < 1e-5, f"Outputs differ too much: mean_diff={mean_diff}"
+
+        # Cleanup
+        transformer.clear_preloaded_loras()
+        del transformer
+
+    def test_output_differs_between_loras(self):
+        """Test that different LoRAs produce different outputs (sanity check)."""
+        precision = get_precision()
+
+        transformer = NunchakuFluxTransformer2dModel.from_pretrained(
+            f"nunchaku-tech/nunchaku-flux.1-krea-dev/svdq-{precision}_r32-flux.1-krea-dev.safetensors"
+        )
+
+        from huggingface_hub import hf_hub_download
+
+        lora_anime = hf_hub_download("XLabs-AI/flux-lora-collection", "anime_lora.safetensors")
+        lora_realism = hf_hub_download("XLabs-AI/flux-lora-collection", "realism_lora.safetensors")
+
+        # Preload both LoRAs
+        transformer.preload_loras(
+            {
+                "anime": lora_anime,
+                "realism": lora_realism,
+                "base": None,
+            }
+        )
+
+        inputs = create_dummy_inputs()
+        outputs = {}
+
+        for name in ["anime", "realism", "base"]:
+            transformer.switch_lora(name)
+            torch.cuda.synchronize()
+
+            with torch.no_grad():
+                output = transformer(**inputs)
+            if isinstance(output, tuple):
+                output = output[0]
+            outputs[name] = output.clone()
+
+        # Compare different LoRAs - they should produce different outputs
+        diff_anime_realism = (outputs["anime"] - outputs["realism"]).abs().mean().item()
+        diff_anime_base = (outputs["anime"] - outputs["base"]).abs().mean().item()
+        diff_realism_base = (outputs["realism"] - outputs["base"]).abs().mean().item()
+
+        _LOGGER.info("Output differences:")
+        _LOGGER.info(f"  anime vs realism: {diff_anime_realism:.6f}")
+        _LOGGER.info(f"  anime vs base:    {diff_anime_base:.6f}")
+        _LOGGER.info(f"  realism vs base:  {diff_realism_base:.6f}")
+
+        # Different LoRAs should produce meaningfully different outputs
+        assert diff_anime_realism > 0.01, "anime and realism LoRAs should produce different outputs"
+        assert diff_anime_base > 0.01, "anime LoRA should differ from base"
+        assert diff_realism_base > 0.01, "realism LoRA should differ from base"
+
+        # Cleanup
+        transformer.clear_preloaded_loras()
+        del transformer


### PR DESCRIPTION
  ## Motivation

  Closes #896

  Current LoRA switching in Nunchaku takes **~100ms+** due to file loading, format conversion, and tensor concatenation on each switch. For real-time interactive applications
   (e.g., users switching between anime/realistic/base styles), this latency is unacceptable.

  This PR implements fast LoRA switching by preloading multiple LoRA variants into GPU memory. Switching becomes a simple `loadDict()` call with GPU-to-GPU memcpy, achieving
  **<1ms switch time**.

  ## Modifications

  1. **New API methods in `NunchakuFluxTransformer2dModel`:**
     - `preload_loras(loras: dict[str, str | None])` - Preload multiple LoRA variants
     - `switch_lora(name: str, strength: float = 1.0)` - Fast switch to preloaded variant
     - `list_preloaded_loras()` - List available variants
     - `get_active_lora()` - Get current active variant
     - `unload_lora_variant(name: str)` - Unload specific variant to free memory
     - `clear_preloaded_loras()` - Clear all preloaded variants

  2. **Performance improvement:**
     - Switch time: ~100ms+ → <1ms (100x+ speedup)
     - One-time preload cost amortized over multiple switches

  3. **Files changed:**
     - `nunchaku/models/transformers/transformer_flux.py` - Core implementation
     - `examples/fast_lora_switching.py` - Usage example with benchmarks
     - `tests/flux/test_fast_lora_switching.py` - Unit and integration tests
     - `tests/flux/test_fast_lora_switching_benchmark.py` - Benchmark tests

  ## Checklist

  - [x] Code is formatted using Pre-Commit hooks.
  - [x] Relevant unit tests are added in the [`tests`](../tests) directory.
  - [x] Example script added in [`examples`](../examples).
  - [x] Throughput/latency benchmarks included in example script and benchmark tests.


@lmxyy

This PR is ready for review.

  ## Run Example
  ```bash
  python examples/fast_lora_switching.py

  Run Tests

  pytest tests/flux/test_fast_lora_switching.py -v
  pytest tests/flux/test_fast_lora_switching_benchmark.py -v