### PR TITLE
Fix/zimage patch model slow

### DIFF
--- a/nunchaku/models/transformers/transformer_zimage.py
+++ b/nunchaku/models/transformers/transformer_zimage.py
@@ -398,8 +398,14 @@ class NunchakuZImageTransformer2DModel(ZImageTransformer2DModel, NunchakuModelLo
         AssertionError
             If the file is not a safetensors file.
         """
-        device = kwargs.get("device", "cpu")
-        offload = kwargs.get("offload", False)
+        # NOTE:
+        # `kwargs` is forwarded into `_patch_model(...)`, and further into quantized layer constructors
+        # (e.g. `SVDQW4A4Linear.from_linear(..., **kwargs)`).
+        # Loader-only arguments like `device` / `offload` (and optional `pin_memory`) must NOT be forwarded,
+        # otherwise they can break layer construction (unexpected/duplicate kwargs).
+        device = kwargs.pop("device", "cpu")
+        offload = kwargs.pop("offload", False)
+        kwargs.pop("pin_memory", None)
 
         if offload:
             raise NotImplementedError("Offload is not supported for ZImageTransformer2DModel")

--- a/nunchaku/models/transformers/transformer_zimage.py
+++ b/nunchaku/models/transformers/transformer_zimage.py
@@ -401,11 +401,10 @@ class NunchakuZImageTransformer2DModel(ZImageTransformer2DModel, NunchakuModelLo
         # NOTE:
         # `kwargs` is forwarded into `_patch_model(...)`, and further into quantized layer constructors
         # (e.g. `SVDQW4A4Linear.from_linear(..., **kwargs)`).
-        # Loader-only arguments like `device` / `offload` (and optional `pin_memory`) must NOT be forwarded,
+        # Loader-only arguments like `device` / `offload` must NOT be forwarded,
         # otherwise they can break layer construction (unexpected/duplicate kwargs).
         device = kwargs.pop("device", "cpu")
         offload = kwargs.pop("offload", False)
-        kwargs.pop("pin_memory", None)
 
         if offload:
             raise NotImplementedError("Offload is not supported for ZImageTransformer2DModel")
@@ -429,7 +428,7 @@ class NunchakuZImageTransformer2DModel(ZImageTransformer2DModel, NunchakuModelLo
         if precision == "fp4":
             precision = "nvfp4"
 
-        print(f"quantization_config: {quantization_config}, rank={rank}, skip_refiners={skip_refiners}")
+        # print(f"quantization_config: {quantization_config}, rank={rank}, skip_refiners={skip_refiners}")
 
         transformer._patch_model(skip_refiners=skip_refiners, precision=precision, rank=rank, **kwargs)
         transformer = transformer.to_empty(device=device)


### PR DESCRIPTION
Motivation
This PR fixes a severe slowdown during ZImage model patching (_patch_model) when loading from .safetensors via NunchakuZImageTransformer2DModel.from_pretrained(...).

In particular, when the model is constructed on the meta device (common in from_pretrained flows that later call to_empty(...) + load_state_dict(...)), patching can become extremely slow due to unnecessary large CPU allocations and transfers to meta.

Additionally, forwarding loader-only kwargs (e.g. device) into _patch_model(...) can break quantized layer construction with duplicate/unexpected keyword arguments, preventing patching from completing.

Modifications
Update _convert_z_image_ff(...) in nunchaku/models/transformers/transformer_zimage.py to be meta-device friendly:
When the target device is meta, construct the diffusers FeedForward module directly under with torch.device("meta") to avoid creating large temporary CPU tensors and then moving them to meta.

Align from_pretrained(...) kwargs handling with the approach used in the vitoom branch:
Pop loader-only args (e.g. device, offload) from kwargs before forwarding the remaining kwargs into _patch_model(...), preventing duplicate device kwargs in quantized layer constructors such as SVDQW4A4Linear.from_linear(...).
Reduce noisy stdout during model loading by disabling the verbose quantization_config print (commented out).
