### PR TITLE
Remove redundant IP-adapter computation & vectorize add_kernel

### DIFF
--- a/src/FluxModel.cpp
+++ b/src/FluxModel.cpp
@@ -1445,10 +1445,10 @@ std::tuple<Tensor, Tensor, Tensor> FluxModel::forward_ip_adapter(size_t layer,
         }
     }
 
-    std::tie(hidden_states, encoder_hidden_states) = transformer_blocks.at(layer)->forward(
-        hidden_states, encoder_hidden_states, temb, rotary_emb_img, rotary_emb_context, 0.0f);
-    Tensor ip_query = transformer_blocks.at(layer)->get_q_heads(
-        hidden_states, encoder_hidden_states, temb, rotary_emb_img, rotary_emb_context, 0.0f);
+    Tensor ip_query;
+    std::tie(hidden_states, encoder_hidden_states, ip_query) =
+        transformer_blocks.at(layer)->forward_ip_adapter_branch(
+            hidden_states, encoder_hidden_states, temb, rotary_emb_img, rotary_emb_context, 0.0f);
 
     if (controlnet_block_samples.valid()) {
         const int num_controlnet_block_samples = controlnet_block_samples.shape[0];

--- a/src/kernels/misc_kernels.cu
+++ b/src/kernels/misc_kernels.cu
@@ -11,15 +11,26 @@ Tensor add(Tensor a, Tensor b) {
     assert(b.is_contiguous());
 
     int threadsPerBlock = 1024;
-    int blocksPerGrid   = (a.numel() + threadsPerBlock - 1) / threadsPerBlock;
 
     auto stream = getCurrentCUDAStream();
 
     Tensor out = Tensor::empty_like(a);
 
+    constexpr int unroll = 8;
+    const bool can_vectorize = (a.numel() % unroll == 0) &&
+                               ((uintptr_t)a.data_ptr() % (a.scalar_size() * unroll) == 0) &&
+                               ((uintptr_t)b.data_ptr() % (b.scalar_size() * unroll) == 0);
+
     dispatch(out.scalar_type(), [&]<typename scalar_t>() {
-        add_kernel<<<blocksPerGrid, threadsPerBlock, 0, stream>>>(
-            a.data_ptr<scalar_t>(), b.data_ptr<scalar_t>(), out.data_ptr<scalar_t>(), out.numel());
+        if (can_vectorize) {
+            int blocksPerGrid = (a.numel() + threadsPerBlock * unroll - 1) / (threadsPerBlock * unroll);
+            add_kernel<scalar_t, unroll><<<blocksPerGrid, threadsPerBlock, 0, stream>>>(
+                a.data_ptr<scalar_t>(), b.data_ptr<scalar_t>(), out.data_ptr<scalar_t>(), out.numel());
+        } else {
+            int blocksPerGrid = (a.numel() + threadsPerBlock - 1) / threadsPerBlock;
+            add_kernel<scalar_t, 1><<<blocksPerGrid, threadsPerBlock, 0, stream>>>(
+                a.data_ptr<scalar_t>(), b.data_ptr<scalar_t>(), out.data_ptr<scalar_t>(), out.numel());
+        }
     });
 
     return out;

--- a/src/kernels/misc_kernels_impl.cuh
+++ b/src/kernels/misc_kernels_impl.cuh
@@ -9,18 +9,29 @@
 
 namespace nunchaku::kernels {
 
-template<typename T>
-__global__ void add_kernel(T *a, T *b, T *c, size_t length) {
-    int i = threadIdx.x + blockIdx.x * blockDim.x;
-    if (i < length) {
-        c[i] = a[i] + b[i];
-    }
-}
-
 template<typename T, int unroll>
 struct alignas(sizeof(T) * unroll) Tvec {
     T data[unroll];
 };
+
+template<typename T, int unroll>
+__global__ void add_kernel(T *a, T *b, T *c, size_t length) {
+    int i = (threadIdx.x + blockIdx.x * blockDim.x) * unroll;
+    if (i >= length) return;
+
+    using Tvec = nunchaku::kernels::Tvec<T, unroll>;
+
+    Tvec ra = *reinterpret_cast<Tvec *>(&a[i]);
+    Tvec rb = *reinterpret_cast<Tvec *>(&b[i]);
+    Tvec rc;
+
+#pragma unroll
+    for (int k = 0; k < unroll; k++) {
+        rc.data[k] = ra.data[k] + rb.data[k];
+    }
+
+    *reinterpret_cast<Tvec *>(&c[i]) = rc;
+}
 
 template<typename T, int unroll, bool no_scale>
 __global__ void mul_add_kernel(T *x,


### PR DESCRIPTION
Changes
                                                                                                                                                                                                                                                                                                   
  1. Remove redundant computation in IP-adapter forward pass
  - Previously, forward() and get_q_heads() were called separately, causing duplicate computation of hidden states
  - Replaced with a single forward_ip_adapter_branch() call that returns both the forward result and ip_query together
  - File: src/FluxModel.cpp

  2. Vectorize add_kernel with 8x unrolling
  - Process 8 elements per thread using Tvec<T, 8>, enabling 128-bit coalesced memory transactions (for BF16)
  - Add alignment/divisibility check with unroll=1 fallback for unaligned tensors
  - Follows the same vectorization pattern already used by mul_add_kernel and quant_kernel_static
  - Files: src/kernels/misc_kernels_impl.cuh, src/kernels/misc_kernels.cu

  Impact

  - IP-adapter: Eliminates redundant forward pass computation for ip_query extraction
  - add_kernel: ~8x theoretical kernel throughput improvement via wider memory transactions. Minimal end-to-end impact since it is not on the critical path for most pipelines.
  - No regressions observed across all tested models

  Tested on

  - FLUX.1-dev (text-to-image, LoRA, IP-adapter)
  - FLUX.1-schnell
  - SANA 1.6B
  - Qwen-Image