### PR TITLE
feat: add FBCache support for HunyuanVideo

### DIFF
--- a/examples/hunyuan-video-cache.py
+++ b/examples/hunyuan-video-cache.py
@@ -1,0 +1,22 @@
+import torch
+from diffusers import HunyuanVideoPipeline, HunyuanVideoTransformer3DModel
+from diffusers.utils import export_to_video
+from nunchaku.caching.diffusers_adapters import apply_cache_on_pipe
+
+transformer = HunyuanVideoTransformer3DModel.from_pretrained(
+    "hunyuanvideo-community/HunyuanVideo", subfolder="transformer", torch_dtype=torch.bfloat16
+)
+pipeline = HunyuanVideoPipeline.from_pretrained(
+    "hunyuanvideo-community/HunyuanVideo", transformer=transformer, torch_dtype=torch.float16
+).to("cuda")
+apply_cache_on_pipe(pipeline, residual_diff_threshold=0.12)
+
+output = pipeline(
+    prompt="A cat walks on the grass, realistic style.",
+    height=512,
+    width=512,
+    num_frames=61,
+    num_inference_steps=50,
+).frames[0]
+
+export_to_video(output, "hunyuan-video-cache.mp4", fps=15)

--- a/nunchaku/caching/diffusers_adapters/__init__.py
+++ b/nunchaku/caching/diffusers_adapters/__init__.py
@@ -68,6 +68,8 @@ def apply_cache_on_pipe(pipe: DiffusionPipeline, *args, **kwargs):
         from .flux import apply_cache_on_pipe as apply_cache_on_pipe_fn
     elif pipe_cls_name.startswith("Sana"):
         from .sana import apply_cache_on_pipe as apply_cache_on_pipe_fn
+    elif pipe_cls_name.startswith("HunyuanVideo"):
+        from .hunyuan_video import apply_cache_on_pipe as apply_cache_on_pipe_fn
     else:
         raise ValueError(f"Unknown pipeline class name: {pipe_cls_name}")
     return apply_cache_on_pipe_fn(pipe, *args, **kwargs)

--- a/nunchaku/caching/diffusers_adapters/hunyuan_video.py
+++ b/nunchaku/caching/diffusers_adapters/hunyuan_video.py
@@ -1,0 +1,254 @@
+"""Adapters for efficient caching in HunyuanVideo diffusion pipelines."""
+
+import functools
+from typing import Any, Dict, Optional, Union
+
+import torch
+from diffusers import DiffusionPipeline
+from diffusers.models.modeling_outputs import Transformer2DModelOutput
+
+from ..fbcache import (
+    cache_context,
+    check_and_apply_cache,
+    create_cache_context,
+    get_buffer,
+    get_can_use_cache,
+    set_buffer,
+)
+
+
+def apply_cache_on_pipe(pipe: DiffusionPipeline, **kwargs):
+    if not getattr(pipe, "_is_cached", False):
+        original_call = pipe.__class__.__call__
+
+        @functools.wraps(original_call)
+        def new_call(self, *args, **kwargs):
+            with cache_context(create_cache_context()):
+                return original_call(self, *args, **kwargs)
+
+        pipe.__class__.__call__ = new_call
+        pipe.__class__._is_cached = True
+
+    apply_cache_on_transformer(pipe.transformer, **kwargs)
+
+    return pipe
+
+
+def apply_cache_on_transformer(
+    transformer,
+    *,
+    use_double_fb_cache: bool = False,
+    residual_diff_threshold: float = 0.12,
+    residual_diff_threshold_multi: float | None = None,
+    residual_diff_threshold_single: float | None = None,
+):
+    if residual_diff_threshold_multi is None:
+        residual_diff_threshold_multi = residual_diff_threshold
+
+    if getattr(transformer, "_is_cached", False):
+        transformer.residual_diff_threshold_multi = residual_diff_threshold_multi
+        transformer.residual_diff_threshold_single = residual_diff_threshold_single
+        transformer.use_double_fb_cache = use_double_fb_cache
+        return transformer
+
+    transformer._original_forward = transformer.forward
+
+    transformer.residual_diff_threshold_multi = residual_diff_threshold_multi
+    transformer.residual_diff_threshold_single = (
+        residual_diff_threshold_single if residual_diff_threshold_single is not None else -1.0
+    )
+    transformer.use_double_fb_cache = use_double_fb_cache
+    transformer.verbose = False
+
+    transformer.forward = cached_forward_hunyuan_video.__get__(transformer, transformer.__class__)
+    transformer._is_cached = True
+
+    return transformer
+
+
+def cached_forward_hunyuan_video(
+    self,
+    hidden_states: torch.Tensor,
+    timestep: torch.LongTensor,
+    encoder_hidden_states: torch.Tensor,
+    encoder_attention_mask: torch.Tensor,
+    pooled_projections: torch.Tensor,
+    guidance: torch.Tensor = None,
+    attention_kwargs: Optional[Dict[str, Any]] = None,
+    return_dict: bool = True,
+) -> Union[tuple[torch.Tensor], Transformer2DModelOutput]:
+    if self.residual_diff_threshold_multi < 0.0:
+        return self._original_forward(
+            hidden_states=hidden_states,
+            timestep=timestep,
+            encoder_hidden_states=encoder_hidden_states,
+            encoder_attention_mask=encoder_attention_mask,
+            pooled_projections=pooled_projections,
+            guidance=guidance,
+            attention_kwargs=attention_kwargs,
+            return_dict=return_dict,
+        )
+
+    from diffusers.utils import USE_PEFT_BACKEND, scale_lora_layers, unscale_lora_layers
+
+    if attention_kwargs is not None:
+        attention_kwargs = attention_kwargs.copy()
+        lora_scale = attention_kwargs.pop("scale", 1.0)
+    else:
+        lora_scale = 1.0
+
+    if USE_PEFT_BACKEND:
+        scale_lora_layers(self, lora_scale)
+
+    batch_size, num_channels, num_frames, height, width = hidden_states.shape
+    p, p_t = self.config.patch_size, self.config.patch_size_t
+    post_patch_num_frames = num_frames // p_t
+    post_patch_height = height // p
+    post_patch_width = width // p
+    first_frame_num_tokens = 1 * post_patch_height * post_patch_width
+
+    image_rotary_emb = self.rope(hidden_states)
+    temb, token_replace_emb = self.time_text_embed(timestep, pooled_projections, guidance)
+    hidden_states = self.x_embedder(hidden_states)
+    encoder_hidden_states = self.context_embedder(encoder_hidden_states, timestep, encoder_attention_mask)
+
+    latent_sequence_length = hidden_states.shape[1]
+    condition_sequence_length = encoder_hidden_states.shape[1]
+    sequence_length = latent_sequence_length + condition_sequence_length
+    attention_mask = torch.ones(batch_size, sequence_length, device=hidden_states.device, dtype=torch.bool)
+    effective_condition_sequence_length = encoder_attention_mask.sum(dim=1, dtype=torch.int)
+    effective_sequence_length = latent_sequence_length + effective_condition_sequence_length
+    indices = torch.arange(sequence_length, device=hidden_states.device).unsqueeze(0)
+    mask_indices = indices >= effective_sequence_length.unsqueeze(1)
+    attention_mask = attention_mask.masked_fill(mask_indices, False)
+    attention_mask = attention_mask.unsqueeze(1).unsqueeze(1)
+
+    block_args = (temb, attention_mask, image_rotary_emb, token_replace_emb, first_frame_num_tokens)
+
+    original_hidden_states = hidden_states
+    first_block = self.transformer_blocks[0]
+    hidden_states, encoder_hidden_states = first_block(hidden_states, encoder_hidden_states, *block_args)
+    first_residual_multi = hidden_states - original_hidden_states
+    del original_hidden_states
+
+    if self.use_double_fb_cache:
+        call_remaining_fn = _run_remaining_multi_blocks
+    else:
+        call_remaining_fn = _run_remaining_all_blocks
+
+    hidden_states, encoder_hidden_states, _ = check_and_apply_cache(
+        first_residual=first_residual_multi,
+        hidden_states=hidden_states,
+        encoder_hidden_states=encoder_hidden_states,
+        threshold=self.residual_diff_threshold_multi,
+        parallelized=False,
+        mode="multi",
+        verbose=getattr(self, "verbose", False),
+        call_remaining_fn=lambda hidden_states, encoder_hidden_states, **kw: call_remaining_fn(
+            self, hidden_states, encoder_hidden_states, *block_args
+        ),
+        remaining_kwargs={},
+    )
+
+    # Single-block caching is handled manually because HunyuanVideo's single blocks
+    if self.use_double_fb_cache:
+        original_hidden_states = hidden_states
+        original_encoder_hidden_states = encoder_hidden_states
+        first_single_block = self.single_transformer_blocks[0]
+        hidden_states, encoder_hidden_states = first_single_block(hidden_states, encoder_hidden_states, *block_args)
+
+        first_residual_single = hidden_states - original_hidden_states
+
+        can_use_cache, diff = get_can_use_cache(
+            first_residual_single, threshold=self.residual_diff_threshold_single, mode="single"
+        )
+
+        if can_use_cache:
+            hs_residual = get_buffer("single_hidden_states_residual")
+            enc_residual = get_buffer("single_encoder_hidden_states_residual")
+            hidden_states = original_hidden_states + hs_residual
+            encoder_hidden_states = original_encoder_hidden_states + enc_residual
+            hidden_states = hidden_states.contiguous()
+            encoder_hidden_states = encoder_hidden_states.contiguous()
+        else:
+            set_buffer("first_single_hidden_states_residual", first_residual_single)
+
+            hidden_states, encoder_hidden_states, hs_residual, enc_residual = _run_remaining_single_blocks(
+                self, hidden_states, encoder_hidden_states, *block_args
+            )
+
+            set_buffer("single_hidden_states_residual", hidden_states - original_hidden_states)
+            set_buffer("single_encoder_hidden_states_residual", encoder_hidden_states - original_encoder_hidden_states)
+
+        del original_hidden_states, original_encoder_hidden_states
+
+    hidden_states = self.norm_out(hidden_states, temb)
+    hidden_states = self.proj_out(hidden_states)
+
+    hidden_states = hidden_states.reshape(
+        batch_size, post_patch_num_frames, post_patch_height, post_patch_width, -1, p_t, p, p
+    )
+    hidden_states = hidden_states.permute(0, 4, 1, 5, 2, 6, 3, 7)
+    hidden_states = hidden_states.flatten(6, 7).flatten(4, 5).flatten(2, 3)
+
+    if USE_PEFT_BACKEND:
+        unscale_lora_layers(self, lora_scale)
+
+    if not return_dict:
+        return (hidden_states,)
+
+    return Transformer2DModelOutput(sample=hidden_states)
+
+
+def _run_remaining_all_blocks(self, hidden_states, encoder_hidden_states, *block_args):
+    """Run remaining dual-stream and all single-stream blocks (single-stage mode)."""
+    original_h = hidden_states
+    original_enc = encoder_hidden_states
+
+    for block in self.transformer_blocks[1:]:
+        hidden_states, encoder_hidden_states = block(hidden_states, encoder_hidden_states, *block_args)
+
+    for block in self.single_transformer_blocks:
+        hidden_states, encoder_hidden_states = block(hidden_states, encoder_hidden_states, *block_args)
+
+    hidden_states = hidden_states.contiguous()
+    encoder_hidden_states = encoder_hidden_states.contiguous()
+
+    hs_residual = hidden_states - original_h
+    enc_residual = encoder_hidden_states - original_enc
+
+    return hidden_states, encoder_hidden_states, hs_residual, enc_residual
+
+
+def _run_remaining_multi_blocks(self, hidden_states, encoder_hidden_states, *block_args):
+    """Run remaining dual-stream blocks only (double-stage mode, stage 1)."""
+    original_h = hidden_states
+    original_enc = encoder_hidden_states
+
+    for block in self.transformer_blocks[1:]:
+        hidden_states, encoder_hidden_states = block(hidden_states, encoder_hidden_states, *block_args)
+
+    hidden_states = hidden_states.contiguous()
+    encoder_hidden_states = encoder_hidden_states.contiguous()
+
+    hs_residual = hidden_states - original_h
+    enc_residual = encoder_hidden_states - original_enc
+
+    return hidden_states, encoder_hidden_states, hs_residual, enc_residual
+
+
+def _run_remaining_single_blocks(self, hidden_states, encoder_hidden_states, *block_args):
+    """Run remaining single-stream blocks (double-stage mode, stage 2)."""
+    original_h = hidden_states
+    original_enc = encoder_hidden_states
+
+    for block in self.single_transformer_blocks[1:]:
+        hidden_states, encoder_hidden_states = block(hidden_states, encoder_hidden_states, *block_args)
+
+    hidden_states = hidden_states.contiguous()
+    encoder_hidden_states = encoder_hidden_states.contiguous()
+
+    hs_residual = hidden_states - original_h
+    enc_residual = encoder_hidden_states - original_enc
+
+    return hidden_states, encoder_hidden_states, hs_residual, enc_residual

--- a/tests/hunyuan_video/test_hunyuan_video_fbcache.py
+++ b/tests/hunyuan_video/test_hunyuan_video_fbcache.py
@@ -1,0 +1,61 @@
+import pytest
+
+from .utils import run_test
+
+
+@pytest.mark.parametrize(
+    "residual_diff_threshold,use_double_fb_cache,residual_diff_threshold_multi,residual_diff_threshold_single,height,width,num_frames,num_inference_steps,expected_lpips",
+    [
+        (0.12, False, None, None, 320, 512, 61, 50, 0.3),
+    ],
+)
+def test_hunyuan_video_fbcache(
+    residual_diff_threshold: float,
+    use_double_fb_cache: bool,
+    residual_diff_threshold_multi: float | None,
+    residual_diff_threshold_single: float | None,
+    height: int,
+    width: int,
+    num_frames: int,
+    num_inference_steps: int,
+    expected_lpips: float,
+):
+    run_test(
+        height=height,
+        width=width,
+        num_frames=num_frames,
+        num_inference_steps=num_inference_steps,
+        residual_diff_threshold=residual_diff_threshold,
+        use_double_fb_cache=use_double_fb_cache,
+        residual_diff_threshold_multi=residual_diff_threshold_multi,
+        residual_diff_threshold_single=residual_diff_threshold_single,
+        expected_lpips=expected_lpips,
+    )
+
+
+@pytest.mark.parametrize(
+    "use_double_fb_cache,residual_diff_threshold_multi,residual_diff_threshold_single,height,width,num_frames,num_inference_steps,expected_lpips",
+    [
+        (True, 0.09, 0.12, 320, 512, 61, 50, 0.3),
+    ],
+)
+def test_hunyuan_video_double_fbcache(
+    use_double_fb_cache: bool,
+    residual_diff_threshold_multi: float,
+    residual_diff_threshold_single: float,
+    height: int,
+    width: int,
+    num_frames: int,
+    num_inference_steps: int,
+    expected_lpips: float,
+):
+    run_test(
+        height=height,
+        width=width,
+        num_frames=num_frames,
+        num_inference_steps=num_inference_steps,
+        use_double_fb_cache=use_double_fb_cache,
+        residual_diff_threshold_multi=residual_diff_threshold_multi,
+        residual_diff_threshold_single=residual_diff_threshold_single,
+        expected_lpips=expected_lpips,
+    )

--- a/tests/hunyuan_video/utils.py
+++ b/tests/hunyuan_video/utils.py
@@ -1,0 +1,102 @@
+import gc
+import os
+
+import torch
+from diffusers import HunyuanVideoPipeline, HunyuanVideoTransformer3DModel
+
+from nunchaku.caching.diffusers_adapters import apply_cache_on_pipe
+
+from ..utils import already_generate, compute_lpips
+
+MODEL_ID = "hunyuanvideo-community/HunyuanVideo"
+PROMPT = "A cat walks on the grass, realistic style."
+SEED = 42
+
+
+def save_video_frames(frames, save_dir: str):
+    os.makedirs(save_dir, exist_ok=True)
+    for i, frame in enumerate(frames):
+        frame.save(os.path.join(save_dir, f"frame_{i:04d}.png"))
+
+
+def load_pipeline(gpu_id: int = 0):
+    transformer = HunyuanVideoTransformer3DModel.from_pretrained(
+        MODEL_ID, subfolder="transformer", torch_dtype=torch.bfloat16
+    )
+    pipe = HunyuanVideoPipeline.from_pretrained(MODEL_ID, transformer=transformer, torch_dtype=torch.float16)
+    pipe.enable_sequential_cpu_offload(gpu_id=gpu_id)
+    pipe.vae.enable_tiling()
+    return pipe
+
+
+def run_test(
+    height: int = 320,
+    width: int = 512,
+    num_frames: int = 61,
+    num_inference_steps: int = 50,
+    residual_diff_threshold: float = 0.12,
+    use_double_fb_cache: bool = False,
+    residual_diff_threshold_multi: float | None = None,
+    residual_diff_threshold_single: float | None = None,
+    expected_lpips: float = 0.3,
+):
+    gc.collect()
+    torch.cuda.empty_cache()
+
+    folder_name = f"w{width}h{height}f{num_frames}t{num_inference_steps}"
+    ref_root = os.environ.get("NUNCHAKU_TEST_CACHE_ROOT", os.path.join("test_results", "ref"))
+    save_dir_ref = os.path.join(ref_root, "bf16", "hunyuan-video", folder_name)
+
+    forward_kwargs = {
+        "prompt": PROMPT,
+        "height": height,
+        "width": width,
+        "num_frames": num_frames,
+        "num_inference_steps": num_inference_steps,
+    }
+
+    # Generate reference video (no cache)
+    if not already_generate(save_dir_ref):
+        pipe = load_pipeline()
+        generator = torch.Generator().manual_seed(SEED)
+        output = pipe(**forward_kwargs, generator=generator)
+        save_video_frames(output.frames[0], save_dir_ref)
+        del pipe
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    # Build cache config string
+    precision_str = "fbcache"
+    if residual_diff_threshold > 0:
+        precision_str += f"-rdt{residual_diff_threshold}"
+    if use_double_fb_cache:
+        precision_str += "-dfb"
+    if residual_diff_threshold_multi is not None:
+        precision_str += f"-rdm{residual_diff_threshold_multi}"
+    if residual_diff_threshold_single is not None:
+        precision_str += f"-rds{residual_diff_threshold_single}"
+
+    save_dir_cached = os.path.join("test_results", "bf16", precision_str, "hunyuan-video", folder_name)
+
+    # Generate cached video
+    pipe = load_pipeline()
+    cache_kwargs = {"residual_diff_threshold": residual_diff_threshold}
+    if use_double_fb_cache:
+        cache_kwargs["use_double_fb_cache"] = True
+    if residual_diff_threshold_multi is not None:
+        cache_kwargs["residual_diff_threshold_multi"] = residual_diff_threshold_multi
+    if residual_diff_threshold_single is not None:
+        cache_kwargs["residual_diff_threshold_single"] = residual_diff_threshold_single
+    apply_cache_on_pipe(pipe, **cache_kwargs)
+
+    generator = torch.Generator().manual_seed(SEED)
+    output = pipe(**forward_kwargs, generator=generator)
+    save_video_frames(output.frames[0], save_dir_cached)
+    del pipe
+    gc.collect()
+    torch.cuda.empty_cache()
+
+    # Compare quality
+    lpips = compute_lpips(save_dir_ref, save_dir_cached)
+    print(f"lpips: {lpips}")
+    assert lpips < expected_lpips * 1.15


### PR DESCRIPTION
## Summary

 - Add FBCache (First-Block Cache) support for `HunyuanVideoTransformer3DModel`
   - **Single-stage FBCache**: caches dual-stream `transformer_blocks` to skip redundant computation when residuals are similar
   - **Double FBCache**: independently caches both dual-stream `transformer_blocks` and single-stream `single_transformer_blocks`
 for more aggressive speedup
 - Register `HunyuanVideo` pipeline in `apply_cache_on_pipe` dispatcher
 - Add example script (`examples/hunyuan-video-cache.py`)
 - Add integration tests following the existing flux test pattern (`utils.py` + parametrized `test_*.py`)

## Performance

  Tested on 320×512, 61 frames, 50 steps (sequential CPU offload):

   | Mode | Time | Speedup |
   |------|------|---------|
   | Baseline (no cache) | 806.27s | 1.00x | 
   | FBCache (`threshold=0.12`) | 253.56s | **3.18x** | 

   ## Usage

   ```python
   from nunchaku.caching.diffusers_adapters import apply_cache_on_pipe

   # Single FBCache
   apply_cache_on_pipe(pipe, residual_diff_threshold=0.12)

   # Double FBCache
   apply_cache_on_pipe(pipe, use_double_fb_cache=True, residual_diff_threshold_multi=0.09, residual_diff_threshold_single=0.12)
   ```