### PR TITLE
feat: add Qwen encoder runtimes (Qwen2.5-VL + Qwen3) for Nunchaku

### DIFF
--- a/nunchaku/__init__.py
+++ b/nunchaku/__init__.py
@@ -5,6 +5,10 @@ from .models import (
     NunchakuSanaTransformer2DModel,
     NunchakuT5EncoderModel,
     NunchakuZImageTransformer2DModel,
+    NunchakuQwenEncoderModel,
+    NunchakuQwen2VLEditEncoderModel,
+    NunchakuQwen2VLTextEncoderModel,
+    NunchakuQwen3TextEncoderModel,
 )
 
 __all__ = [
@@ -14,4 +18,8 @@ __all__ = [
     "NunchakuFluxTransformer2DModelV2",
     "NunchakuQwenImageTransformer2DModel",
     "NunchakuZImageTransformer2DModel",
+    "NunchakuQwenEncoderModel",
+    "NunchakuQwen2VLEditEncoderModel",
+    "NunchakuQwen2VLTextEncoderModel",
+    "NunchakuQwen3TextEncoderModel",
 ]

--- a/nunchaku/models/__init__.py
+++ b/nunchaku/models/__init__.py
@@ -1,4 +1,9 @@
 from .text_encoders.t5_encoder import NunchakuT5EncoderModel
+from .text_encoders.qwen_encoder import NunchakuQwenEncoderModel
+from .text_encoders.qwen2_vl_edit_encoder import NunchakuQwen2VLEditEncoderModel
+from .text_encoders.qwen2_vl_text_encoder import NunchakuQwen2VLTextEncoderModel
+from .text_encoders.qwen3_text_encoder import NunchakuQwen3TextEncoderModel
+
 from .transformers import (
     NunchakuFluxTransformer2dModel,
     NunchakuFluxTransformer2DModelV2,
@@ -14,4 +19,8 @@ __all__ = [
     "NunchakuFluxTransformer2DModelV2",
     "NunchakuQwenImageTransformer2DModel",
     "NunchakuZImageTransformer2DModel",
+    "NunchakuQwenEncoderModel",
+    "NunchakuQwen2VLEditEncoderModel",
+    "NunchakuQwen2VLTextEncoderModel",
+    "NunchakuQwen3TextEncoderModel",
 ]

--- a/nunchaku/models/text_encoders/__init__.py
+++ b/nunchaku/models/text_encoders/__init__.py
@@ -1,0 +1,13 @@
+from .qwen_encoder import NunchakuQwenEncoderModel
+from .qwen2_vl_edit_encoder import NunchakuQwen2VLEditEncoderModel
+from .qwen2_vl_text_encoder import NunchakuQwen2VLTextEncoderModel
+from .t5_encoder import NunchakuT5EncoderModel
+from .qwen3_text_encoder import NunchakuQwen3TextEncoderModel
+
+__all__ = [
+    "NunchakuQwenEncoderModel",
+    "NunchakuQwen2VLEditEncoderModel",
+    "NunchakuQwen2VLTextEncoderModel",
+    "NunchakuQwen3TextEncoderModel",
+    "NunchakuT5EncoderModel",
+]

--- a/nunchaku/models/text_encoders/qwen2_vl_edit_encoder.py
+++ b/nunchaku/models/text_encoders/qwen2_vl_edit_encoder.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import typing as tp
+
+import torch
+import torch.nn as nn
+from transformers.models.qwen2_5_vl.configuration_qwen2_5_vl import Qwen2_5_VLConfig
+from transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import Qwen2_5_VLModel
+
+from .qwen_common import (
+    BaseNunchakuQwenEncoderModel,
+    NunchakuQwenCheckpointMetadata,
+    build_full_qwen_config_dict,
+)
+
+__all__ = ["NunchakuQwen2VLEditEncoderModel"]
+
+
+class NunchakuQwen2VLEditEncoderModel(BaseNunchakuQwenEncoderModel):
+    config_class = Qwen2_5_VLConfig
+    _runtime_model_class = Qwen2_5_VLModel
+    _runtime_display_name = "Qwen edit encoder"
+
+    _EDIT_UNSUPPORTED_ARGS = ("labels", "logits_to_keep", "pixel_values_videos", "video_grid_thw", "second_per_grid_ts")
+
+    # -- __init__ hooks -------------------------------------------------------
+
+    def _pre_super_init(self, model: nn.Module) -> None:
+        # PreTrainedModel.__init__ may override _attn_implementation based on
+        # config, so we temporarily set all sub-configs to "eager" and stash the
+        # originals for post-init restoration.
+        configs = self._collect_sub_configs(model)
+        self._saved_attn_impl = {key: getattr(cfg, "_attn_implementation", None) for key, cfg in configs.items()}
+        for cfg in configs.values():
+            cfg._attn_implementation = "eager"
+
+    def _post_super_init(self, model: nn.Module) -> None:
+        for key, cfg in self._collect_sub_configs(self.model).items():
+            original = self._saved_attn_impl.get(key)
+            if original is not None:
+                cfg._attn_implementation = original
+        del self._saved_attn_impl
+
+    # -- Config hooks ---------------------------------------------------------
+
+    @classmethod
+    def _build_config_dict(cls, metadata: NunchakuQwenCheckpointMetadata) -> dict[str, tp.Any]:
+        return build_full_qwen_config_dict(metadata)
+
+    @classmethod
+    def _validate_config(cls, config_dict: dict[str, tp.Any], metadata: NunchakuQwenCheckpointMetadata) -> None:
+        text_config = (
+            config_dict.get("text_config")
+            if isinstance(config_dict.get("text_config"), dict)
+            else config_dict
+        )
+        rope_scaling = text_config.get("rope_scaling")
+        if rope_scaling is None:
+            raise ValueError(
+                "Missing `rope_scaling` in exported Qwen text metadata. "
+                "Please re-export the text encoder with the updated deepcompressor exporter."
+            )
+        if not isinstance(rope_scaling, dict) or "mrope_section" not in rope_scaling:
+            raise ValueError(
+                "Invalid `rope_scaling` in exported Qwen text metadata. "
+                "Expected a dict containing `mrope_section`."
+            )
+
+    @classmethod
+    def _build_runtime_config(cls, metadata: NunchakuQwenCheckpointMetadata, config_dict: dict[str, tp.Any]):
+        config = Qwen2_5_VLConfig(**config_dict)
+        top_attn = cls._resolve_attn_implementation(config_dict, None)
+        text_attn = cls._resolve_attn_implementation(config_dict, "text_config")
+        vision_attn = cls._resolve_attn_implementation(config_dict, "vision_config")
+        config._attn_implementation = top_attn
+        config.text_config._attn_implementation = text_attn
+        config.vision_config._attn_implementation = vision_attn
+        return config
+
+    @classmethod
+    def _post_patch_config(cls, model: nn.Module, config_dict: dict[str, tp.Any]) -> None:
+        model.config._attn_implementation = cls._resolve_attn_implementation(config_dict, None)
+        model.language_model.config._attn_implementation = cls._resolve_attn_implementation(config_dict, "text_config")
+        model.visual.config._attn_implementation = cls._resolve_attn_implementation(config_dict, "vision_config")
+
+    # -- Helpers --------------------------------------------------------------
+
+    @staticmethod
+    def _collect_sub_configs(model: nn.Module) -> dict[str, tp.Any]:
+        configs: dict[str, tp.Any] = {"top": model.config}
+        if hasattr(model, "language_model") and hasattr(model.language_model, "config"):
+            configs["text"] = model.language_model.config
+        if hasattr(model, "visual") and hasattr(model.visual, "config"):
+            configs["vision"] = model.visual.config
+        return configs
+
+    @staticmethod
+    def _resolve_attn_implementation(config_dict: dict[str, tp.Any], nested_key: str | None) -> str:
+        if nested_key is None:
+            value = config_dict.get("_attn_implementation")
+        else:
+            nested = config_dict.get(nested_key)
+            value = nested.get("_attn_implementation") if isinstance(nested, dict) else None
+            if value is None:
+                value = config_dict.get("_attn_implementation")
+        return str(value or "sdpa")
+
+    # -- forward --------------------------------------------------------------
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_values=None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        use_cache: bool | None = None,
+        output_hidden_states: bool | None = None,
+        return_dict: bool = True,
+        pixel_values: torch.Tensor | None = None,
+        pixel_values_videos: torch.FloatTensor | None = None,
+        image_grid_thw: torch.LongTensor | None = None,
+        video_grid_thw: torch.LongTensor | None = None,
+        rope_deltas: torch.LongTensor | None = None,
+        mm_token_type_ids: torch.IntTensor | None = None,
+        second_per_grid_ts: torch.Tensor | None = None,
+        labels: torch.LongTensor | None = None,
+        logits_to_keep: int | torch.Tensor = 0,
+        **kwargs: tp.Any,
+    ) -> tp.Any:
+        unsupported: list[str] = []
+        if labels is not None:
+            unsupported.append("labels")
+        if isinstance(logits_to_keep, torch.Tensor) or int(logits_to_keep) != 0:
+            unsupported.append("logits_to_keep")
+        if pixel_values_videos is not None:
+            unsupported.append("pixel_values_videos")
+        if video_grid_thw is not None:
+            unsupported.append("video_grid_thw")
+        if second_per_grid_ts is not None:
+            unsupported.append("second_per_grid_ts")
+        if unsupported:
+            raise NotImplementedError(
+                "NunchakuQwen2VLEditEncoderModel currently supports image editing only; "
+                f"unsupported args: {sorted(unsupported)}"
+            )
+        if (pixel_values is not None or image_grid_thw is not None) and input_ids is None and inputs_embeds is None:
+            raise ValueError("Multimodal edit encoding requires `input_ids` or `inputs_embeds` to place vision tokens.")
+        if rope_deltas is not None:
+            self.model.rope_deltas = rope_deltas
+        return self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            use_cache=use_cache,
+            pixel_values=pixel_values,
+            pixel_values_videos=None,
+            image_grid_thw=image_grid_thw,
+            video_grid_thw=None,
+            rope_deltas=rope_deltas,
+            mm_token_type_ids=mm_token_type_ids,
+            second_per_grid_ts=None,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+            **kwargs,
+        )

--- a/nunchaku/models/text_encoders/qwen2_vl_text_encoder.py
+++ b/nunchaku/models/text_encoders/qwen2_vl_text_encoder.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import typing as tp
+
+import torch
+
+from transformers.models.qwen2_5_vl.configuration_qwen2_5_vl import Qwen2_5_VLTextConfig as QwenTextConfig
+from transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import Qwen2_5_VLTextModel as QwenTextModel
+
+from .qwen_common import BaseNunchakuQwenEncoderModel, NunchakuQwenCheckpointMetadata
+
+__all__ = ["NunchakuQwen2VLTextEncoderModel"]
+
+_TEXT_ONLY_UNSUPPORTED_ARGS = (
+    "pixel_values",
+    "pixel_values_videos",
+    "image_grid_thw",
+    "video_grid_thw",
+    "rope_deltas",
+    "mm_token_type_ids",
+    "second_per_grid_ts",
+    "labels",
+    "logits_to_keep",
+)
+
+
+class NunchakuQwen2VLTextEncoderModel(BaseNunchakuQwenEncoderModel):
+    config_class = QwenTextConfig
+    _runtime_model_class = QwenTextModel
+    _runtime_display_name = "Qwen text encoder"
+
+    @classmethod
+    def _validate_config(cls, config_dict: dict[str, tp.Any], metadata: NunchakuQwenCheckpointMetadata) -> None:
+        rope_scaling = config_dict.get("rope_scaling")
+        if rope_scaling is None:
+            raise ValueError(
+                "Missing `rope_scaling` in exported Qwen text metadata. "
+                "Please re-export the text encoder with the updated deepcompressor exporter."
+            )
+        if not isinstance(rope_scaling, dict) or "mrope_section" not in rope_scaling:
+            raise ValueError(
+                "Invalid `rope_scaling` in exported Qwen text metadata. "
+                "Expected a dict containing `mrope_section`."
+            )
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_values=None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        use_cache: bool | None = None,
+        output_hidden_states: bool | None = None,
+        return_dict: bool | None = True,
+        pixel_values: torch.Tensor | None = None,
+        pixel_values_videos: torch.FloatTensor | None = None,
+        image_grid_thw: torch.LongTensor | None = None,
+        video_grid_thw: torch.LongTensor | None = None,
+        rope_deltas: torch.LongTensor | None = None,
+        mm_token_type_ids: torch.IntTensor | None = None,
+        second_per_grid_ts: torch.Tensor | None = None,
+        labels: torch.LongTensor | None = None,
+        logits_to_keep: int | torch.Tensor = 0,
+        **kwargs: tp.Any,
+    ) -> tp.Any:
+        explicit_values = {
+            "pixel_values": pixel_values,
+            "pixel_values_videos": pixel_values_videos,
+            "image_grid_thw": image_grid_thw,
+            "video_grid_thw": video_grid_thw,
+            "rope_deltas": rope_deltas,
+            "mm_token_type_ids": mm_token_type_ids,
+            "second_per_grid_ts": second_per_grid_ts,
+            "labels": labels,
+        }
+        unsupported = [
+            name
+            for name, value in explicit_values.items()
+            if name in _TEXT_ONLY_UNSUPPORTED_ARGS and value is not None
+        ]
+        if isinstance(logits_to_keep, torch.Tensor) or int(logits_to_keep) != 0:
+            unsupported.append("logits_to_keep")
+        if unsupported:
+            raise NotImplementedError(
+                f"{type(self).__name__} only supports the QwenImage text-only path; "
+                f"unsupported kwargs: {sorted(unsupported)}"
+            )
+        return self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            use_cache=use_cache,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+            **kwargs,
+        )

--- a/nunchaku/models/text_encoders/qwen3_text_encoder.py
+++ b/nunchaku/models/text_encoders/qwen3_text_encoder.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import typing as tp
+
+import torch
+
+from transformers.models.qwen3.configuration_qwen3 import Qwen3Config
+from transformers.models.qwen3.modeling_qwen3 import Qwen3Model
+
+from .qwen_common import BaseNunchakuQwenEncoderModel, NunchakuQwenCheckpointMetadata
+
+__all__ = ["NunchakuQwen3TextEncoderModel"]
+
+_TEXT_ONLY_UNSUPPORTED_ARGS = (
+    "pixel_values",
+    "pixel_values_videos",
+    "image_grid_thw",
+    "video_grid_thw",
+    "rope_deltas",
+    "mm_token_type_ids",
+    "second_per_grid_ts",
+    "labels",
+    "logits_to_keep",
+)
+
+
+class NunchakuQwen3TextEncoderModel(BaseNunchakuQwenEncoderModel):
+    config_class = Qwen3Config
+    _runtime_model_class = Qwen3Model
+    _runtime_display_name = "Qwen3 text encoder"
+
+    @classmethod
+    def _validate_config(cls, config_dict: dict[str, tp.Any], metadata: NunchakuQwenCheckpointMetadata) -> None:
+        rope_parameters = config_dict.get("rope_parameters")
+        if rope_parameters is None:
+            raise ValueError(
+                "Missing `rope_parameters` in exported Qwen3 text metadata. "
+                "Please re-export the text encoder with the updated deepcompressor exporter."
+            )
+        if not isinstance(rope_parameters, dict) or "rope_theta" not in rope_parameters:
+            raise ValueError(
+                "Invalid `rope_parameters` in exported Qwen3 text metadata. "
+                "Expected a dict containing `rope_theta`."
+            )
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_values=None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        use_cache: bool | None = None,
+        output_hidden_states: bool | None = None,
+        return_dict: bool | None = True,
+        pixel_values: torch.Tensor | None = None,
+        pixel_values_videos: torch.FloatTensor | None = None,
+        image_grid_thw: torch.LongTensor | None = None,
+        video_grid_thw: torch.LongTensor | None = None,
+        rope_deltas: torch.LongTensor | None = None,
+        mm_token_type_ids: torch.IntTensor | None = None,
+        second_per_grid_ts: torch.Tensor | None = None,
+        labels: torch.LongTensor | None = None,
+        logits_to_keep: int | torch.Tensor = 0,
+        **kwargs: tp.Any,
+    ) -> tp.Any:
+        explicit_values = {
+            "pixel_values": pixel_values,
+            "pixel_values_videos": pixel_values_videos,
+            "image_grid_thw": image_grid_thw,
+            "video_grid_thw": video_grid_thw,
+            "rope_deltas": rope_deltas,
+            "mm_token_type_ids": mm_token_type_ids,
+            "second_per_grid_ts": second_per_grid_ts,
+            "labels": labels,
+        }
+        unsupported = [
+            name
+            for name, value in explicit_values.items()
+            if name in _TEXT_ONLY_UNSUPPORTED_ARGS and value is not None
+        ]
+        if isinstance(logits_to_keep, torch.Tensor) or int(logits_to_keep) != 0:
+            unsupported.append("logits_to_keep")
+        if unsupported:
+            raise NotImplementedError(
+                f"{type(self).__name__} only supports the text-only path; "
+                f"unsupported kwargs: {sorted(unsupported)}"
+            )
+        return self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            use_cache=use_cache,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+            **kwargs,
+        )

--- a/nunchaku/models/text_encoders/qwen_common.py
+++ b/nunchaku/models/text_encoders/qwen_common.py
@@ -1,0 +1,558 @@
+from __future__ import annotations
+
+import json
+import typing as tp
+from dataclasses import dataclass
+from pathlib import Path
+
+import safetensors
+import torch
+import torch.nn as nn
+from accelerate import init_empty_weights
+from transformers import PreTrainedModel
+from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
+
+from ...torch_transfer_utils import normalize_device, resolve_pin_memory
+from .linear import W4Linear
+
+__all__ = [
+    "BaseNunchakuQwenEncoderModel",
+    "collect_qwen_quantized_prefixes",
+    "collect_required_qwen_quantized_prefixes",
+    "NunchakuQwenCheckpointMetadata",
+    "build_full_qwen_config_dict",
+    "load_qwen_checkpoint_metadata",
+    "load_qwen_runtime_state_dict",
+    "materialize_meta_module_tensors",
+    "patch_qwen_runtime_linears",
+    "register_rotary_materializer",
+    "restore_qwen_runtime_model_tensors",
+    "resolve_checkpoint_path",
+]
+
+# Keep the old name importable for backward compatibility.
+BaseNunchakuQwenTextEncoderModel: tp.TypeAlias = "BaseNunchakuQwenEncoderModel"
+
+
+# ---------------------------------------------------------------------------
+# P1: Rotary buffer materializer registry
+# ---------------------------------------------------------------------------
+
+RotaryMaterializerFn = tp.Callable[[nn.Module, str, torch.device], torch.Tensor | None]
+_ROTARY_MATERIALIZERS: dict[str, RotaryMaterializerFn] = {}
+
+
+def register_rotary_materializer(class_name: str):
+    """Decorator that registers a rotary-buffer materializer for *class_name*."""
+    def decorator(fn: RotaryMaterializerFn) -> RotaryMaterializerFn:
+        _ROTARY_MATERIALIZERS[class_name] = fn
+        return fn
+    return decorator
+
+
+@register_rotary_materializer("Qwen2_5_VisionRotaryEmbedding")
+def _materialize_vision_rotary(owner: nn.Module, name: str, device: torch.device) -> torch.Tensor | None:
+    if name != "inv_freq":
+        return None
+    dim = int(getattr(owner, "dim"))
+    theta = float(getattr(owner, "theta"))
+    return 1.0 / (theta ** (torch.arange(0, dim, 2, dtype=torch.float, device=device) / dim))
+
+
+def _materialize_rope_with_init_fn(owner: nn.Module, name: str, device: torch.device) -> torch.Tensor | None:
+    """Shared materializer for RoPE embeddings that use ``compute_default_rope_parameters``."""
+    if name not in ("inv_freq", "original_inv_freq"):
+        return None
+    config = getattr(owner, "config")
+    rope_type = str(getattr(owner, "rope_type", config.rope_parameters["rope_type"]))
+    rope_init_fn = owner.compute_default_rope_parameters
+    if rope_type != "default":
+        rope_init_fn = ROPE_INIT_FUNCTIONS[rope_type]
+    inv_freq, attention_scaling = rope_init_fn(config, device)
+    owner.attention_scaling = attention_scaling
+    if name == "original_inv_freq":
+        return inv_freq.clone()
+    return inv_freq
+
+
+register_rotary_materializer("Qwen2_5_VLRotaryEmbedding")(_materialize_rope_with_init_fn)
+register_rotary_materializer("Qwen3RotaryEmbedding")(_materialize_rope_with_init_fn)
+
+
+def _materialize_qwen_rotary_buffer(
+    owner: nn.Module,
+    *,
+    name: str,
+    device: torch.device,
+) -> torch.Tensor | None:
+    materializer = _ROTARY_MATERIALIZERS.get(type(owner).__name__)
+    if materializer is not None:
+        return materializer(owner, name, device)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+@dataclass(slots=True)
+class NunchakuQwenCheckpointMetadata:
+    config: dict[str, tp.Any]
+    base_text_config: dict[str, tp.Any]
+    base_vision_config: dict[str, tp.Any]
+    quantization_config: dict[str, tp.Any]
+    text_quantization_config: dict[str, tp.Any]
+    vision_quantization_config: dict[str, tp.Any]
+    text_encoder_usage: str
+
+
+# ---------------------------------------------------------------------------
+# P0 + P2: Unified base class with hook methods
+# ---------------------------------------------------------------------------
+
+class BaseNunchakuQwenEncoderModel(PreTrainedModel):
+    """Unified base class for all Nunchaku Qwen encoder runtimes.
+
+    Sub-classes only need to set a few class attributes and optionally
+    override hook methods to customise config building, model construction,
+    post-patch fixups, and validation.
+    """
+
+    base_model_prefix = "model"
+    config_class: tp.ClassVar[tp.Any] = None
+    _runtime_model_class: tp.ClassVar[tp.Any] = None
+    _runtime_display_name: tp.ClassVar[str] = "Qwen encoder"
+
+    # -- Hook: __init__ customisation ----------------------------------------
+
+    def __init__(self, *, model: nn.Module, metadata: NunchakuQwenCheckpointMetadata) -> None:
+        self._pre_super_init(model)
+        super().__init__(model.config)
+        self.model = model
+        self.metadata = metadata
+        self.config = model.config
+        self._post_super_init(model)
+
+    def _pre_super_init(self, model: nn.Module) -> None:
+        """Called before ``PreTrainedModel.__init__``.  Default: set eager attn."""
+        model.config._attn_implementation = "eager"
+
+    def _post_super_init(self, model: nn.Module) -> None:
+        """Called after ``PreTrainedModel.__init__``.  Default: no-op."""
+
+    # -- Hook: dtype ----------------------------------------------------------
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return next(self.model.parameters()).dtype
+
+    # -- Hook: config dict building (P2 validation lives here) ----------------
+
+    @classmethod
+    def _build_config_dict(cls, metadata: NunchakuQwenCheckpointMetadata) -> dict[str, tp.Any]:
+        """Return the raw config dict used to construct the runtime config.
+
+        Text-only encoders return ``metadata.base_text_config``;
+        multimodal encoders override this to use ``build_full_qwen_config_dict``.
+        """
+        return dict(metadata.base_text_config)
+
+    @classmethod
+    def _validate_config(cls, config_dict: dict[str, tp.Any], metadata: NunchakuQwenCheckpointMetadata) -> None:
+        """P2: Per-subclass config validation.  Default checks ``rope_scaling``."""
+        rope_scaling = config_dict.get("rope_scaling")
+        if rope_scaling is None:
+            raise ValueError(
+                "Missing `rope_scaling` in exported Qwen text metadata. "
+                "Please re-export the text encoder with the updated deepcompressor exporter."
+            )
+        if not isinstance(rope_scaling, dict) or "mrope_section" not in rope_scaling:
+            raise ValueError(
+                "Invalid `rope_scaling` in exported Qwen text metadata. "
+                "Expected a dict containing `mrope_section`."
+            )
+
+    # -- Hook: runtime config / model creation --------------------------------
+
+    @classmethod
+    def _build_runtime_config(cls, metadata: NunchakuQwenCheckpointMetadata, config_dict: dict[str, tp.Any]):
+        if cls.config_class is None:
+            raise TypeError(f"{cls.__name__} must define `config_class`.")
+        config = cls.config_class(**config_dict)
+        config._attn_implementation = "eager"
+        return config
+
+    @classmethod
+    def _build_runtime_model(cls, config):
+        if cls._runtime_model_class is None:
+            raise TypeError(f"{cls.__name__} must define `_runtime_model_class`.")
+        return cls._runtime_model_class(config)
+
+    # -- Hook: post-patch fixup -----------------------------------------------
+
+    @classmethod
+    def _post_patch_config(cls, model: nn.Module, config_dict: dict[str, tp.Any]) -> None:
+        """Fixup config attributes after quantized linears have been patched.
+
+        Default: reset ``config._attn_implementation`` to ``"eager"``.
+        Multimodal sub-classes override to set per-sub-model attn implementations.
+        """
+        model.config._attn_implementation = "eager"
+
+    # -- Unified from_pretrained (P0) -----------------------------------------
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path,
+        *,
+        device: str | torch.device = "cpu",
+        torch_dtype: torch.dtype | None = None,
+        pin_memory: bool | str = "auto",
+    ):
+        ckpt = resolve_checkpoint_path(pretrained_model_name_or_path)
+        if torch_dtype is None:
+            torch_dtype = torch.bfloat16
+        device = device if isinstance(device, torch.device) else torch.device(device)
+        pin_memory_enabled = resolve_pin_memory(pin_memory, device)
+        with safetensors.safe_open(str(ckpt), framework="pt", device="cpu") as handle:
+            metadata = load_qwen_checkpoint_metadata(handle)
+            config_dict = cls._build_config_dict(metadata)
+            cls._validate_config(config_dict, metadata)
+            config = cls._build_runtime_config(metadata, config_dict)
+            with init_empty_weights():
+                model = cls._build_runtime_model(config)
+            quantized_prefixes = collect_required_qwen_quantized_prefixes(
+                handle,
+                runtime_display_name=cls._runtime_display_name,
+            )
+            patch_qwen_runtime_linears(
+                model,
+                metadata=metadata,
+                quantized_prefixes=quantized_prefixes,
+                linear_dtype=torch_dtype,
+            )
+            cls._post_patch_config(model, config_dict)
+            missing, unexpected = restore_qwen_runtime_model_tensors(
+                handle,
+                model=model,
+                torch_dtype=torch_dtype,
+                output_device=device,
+                pin_memory=pin_memory_enabled,
+            )
+        if missing or unexpected:
+            raise RuntimeError(
+                f"Failed to restore {cls._runtime_display_name} strictly enough. "
+                f"missing={missing[:12]}, unexpected={unexpected[:12]}"
+            )
+        model.eval()
+        return cls(model=model, metadata=metadata)
+
+    # -- forward (sub-classes override) ---------------------------------------
+
+    def forward(self, *args: tp.Any, **kwargs: tp.Any) -> tp.Any:
+        raise NotImplementedError(f"{type(self).__name__} must implement forward().")
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint helpers (unchanged)
+# ---------------------------------------------------------------------------
+
+def _parse_json_metadata(metadata: dict[str, str], key: str, default: tp.Any) -> tp.Any:
+    value = metadata.get(key)
+    if value is None or not str(value).strip():
+        return default
+    return json.loads(value)
+
+
+def resolve_checkpoint_path(pretrained_model_name_or_path: str | Path) -> Path:
+    ckpt = Path(pretrained_model_name_or_path).expanduser().resolve()
+    if not ckpt.exists():
+        raise FileNotFoundError(str(ckpt))
+    return ckpt
+
+
+def load_qwen_checkpoint_metadata(handle: safetensors.safe_open) -> NunchakuQwenCheckpointMetadata:
+    metadata = dict(handle.metadata() or {})
+    config = _parse_json_metadata(metadata, "config", {})
+    base_text_config = _parse_json_metadata(metadata, "base_text_config", {})
+    base_vision_config = _parse_json_metadata(metadata, "base_vision_config", {})
+    quantization_config = _parse_json_metadata(metadata, "quantization_config", {})
+    text_quantization_config = _parse_json_metadata(metadata, "text_quantization_config", quantization_config)
+    vision_quantization_config = _parse_json_metadata(metadata, "vision_quantization_config", {})
+    if not base_text_config and isinstance(config, dict):
+        if isinstance(config.get("text_config"), dict):
+            base_text_config = dict(config["text_config"])
+        else:
+            base_text_config = dict(config)
+    if "rope_scaling" not in base_text_config and isinstance(config, dict) and config.get("rope_scaling") is not None:
+        base_text_config = dict(base_text_config)
+        base_text_config["rope_scaling"] = config["rope_scaling"]
+    if not base_vision_config and isinstance(config, dict) and isinstance(config.get("vision_config"), dict):
+        base_vision_config = dict(config["vision_config"])
+    return NunchakuQwenCheckpointMetadata(
+        config=tp.cast(dict[str, tp.Any], config if isinstance(config, dict) else {}),
+        base_text_config=tp.cast(dict[str, tp.Any], base_text_config if isinstance(base_text_config, dict) else {}),
+        base_vision_config=tp.cast(dict[str, tp.Any], base_vision_config if isinstance(base_vision_config, dict) else {}),
+        quantization_config=tp.cast(dict[str, tp.Any], quantization_config if isinstance(quantization_config, dict) else {}),
+        text_quantization_config=tp.cast(
+            dict[str, tp.Any], text_quantization_config if isinstance(text_quantization_config, dict) else {}
+        ),
+        vision_quantization_config=tp.cast(
+            dict[str, tp.Any], vision_quantization_config if isinstance(vision_quantization_config, dict) else {}
+        ),
+        text_encoder_usage=str(metadata.get("text_encoder_usage", "qwenimage_text_only")),
+    )
+
+
+def build_full_qwen_config_dict(metadata: NunchakuQwenCheckpointMetadata) -> dict[str, tp.Any]:
+    config = dict(metadata.config)
+    if not isinstance(config.get("text_config"), dict) and metadata.base_text_config:
+        config["text_config"] = dict(metadata.base_text_config)
+    elif isinstance(config.get("text_config"), dict) and metadata.base_text_config:
+        merged_text_config = dict(config["text_config"])
+        for key, value in metadata.base_text_config.items():
+            merged_text_config.setdefault(key, value)
+        config["text_config"] = merged_text_config
+    if not isinstance(config.get("vision_config"), dict) and metadata.base_vision_config:
+        config["vision_config"] = dict(metadata.base_vision_config)
+    if "rope_scaling" not in config:
+        if metadata.base_text_config.get("rope_scaling") is not None:
+            config["rope_scaling"] = metadata.base_text_config["rope_scaling"]
+        elif metadata.config.get("rope_scaling") is not None:
+            config["rope_scaling"] = metadata.config["rope_scaling"]
+    if isinstance(config.get("text_config"), dict) and "rope_scaling" not in config["text_config"] and config.get("rope_scaling") is not None:
+        merged_text_config = dict(config["text_config"])
+        merged_text_config["rope_scaling"] = config["rope_scaling"]
+        config["text_config"] = merged_text_config
+    return config
+
+
+# ---------------------------------------------------------------------------
+# Quantization helpers (unchanged)
+# ---------------------------------------------------------------------------
+
+def collect_qwen_quantized_prefixes(keys: tp.Iterable[str]) -> set[str]:
+    return {key[: -len(".qweight")] for key in keys if key.endswith(".qweight")}
+
+
+def collect_required_qwen_quantized_prefixes(
+    handle: safetensors.safe_open, *, runtime_display_name: str
+) -> set[str]:
+    quantized_prefixes = collect_qwen_quantized_prefixes(handle.keys())
+    if not quantized_prefixes:
+        raise ValueError(
+            f"Expected exported {runtime_display_name} runtime weights with quantized `qweight` tensors, "
+            "but the checkpoint does not contain any quantized linear prefixes."
+        )
+    return quantized_prefixes
+
+
+def _unpack_tinychat_w4(qweight: torch.Tensor, *, oc: int, ic: int) -> torch.Tensor:
+    packed_oc = oc // 4
+    if tuple(qweight.shape) != (packed_oc, ic):
+        raise ValueError(f"Expected qweight shape {(packed_oc, ic)}, got {tuple(qweight.shape)}")
+    packed = qweight.detach().cpu().to(dtype=torch.int16).contiguous()
+    packed = packed.view(packed_oc, ic // 64, 4, 16).permute(0, 2, 1, 3).contiguous()
+    packed_vals = packed.reshape(-1, 8).to(dtype=torch.int32)
+    v0 = packed_vals & 0xF
+    v1 = (packed_vals >> 4) & 0xF
+    v2 = (packed_vals >> 8) & 0xF
+    v3 = (packed_vals >> 12) & 0xF
+    return torch.stack([v0, v1, v2, v3], dim=1).reshape(oc, ic)
+
+
+def _dequant_tinychat_linear(
+    *,
+    qweight: torch.Tensor,
+    scales: torch.Tensor,
+    scaled_zeros: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    target_dtype: torch.dtype = torch.bfloat16,
+    group_size: int,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    if group_size <= 0:
+        raise ValueError(f"Invalid group_size: {group_size}")
+    oc = int(scales.shape[1])
+    ic = int(qweight.shape[1])
+    if oc % 4 != 0:
+        raise ValueError(f"Expected output features divisible by 4, got {oc}")
+    if ic % group_size != 0:
+        raise ValueError(f"Expected input features {ic} divisible by group_size {group_size}")
+    ng = ic // group_size
+    q_int = _unpack_tinychat_w4(qweight, oc=oc, ic=ic).to(dtype=torch.float32)
+    scale = scales[:ng].detach().cpu().transpose(0, 1).reshape(oc, ng, 1).to(dtype=torch.float32)
+    zero = scaled_zeros[:ng].detach().cpu().transpose(0, 1).reshape(oc, ng, 1).to(dtype=torch.float32)
+    weight = q_int.view(oc, ng, group_size) * scale + zero
+    dequant_weight = weight.view(oc, ic).to(dtype=target_dtype)
+    dequant_bias = None if bias is None else bias.detach().cpu().to(dtype=target_dtype)
+    return dequant_weight, dequant_bias
+
+
+def _resolve_quant_group_size(metadata: NunchakuQwenCheckpointMetadata) -> int:
+    quant_configs = (
+        metadata.quantization_config,
+        metadata.text_quantization_config,
+        metadata.vision_quantization_config,
+    )
+    for config in quant_configs:
+        group_size = int(config.get("weight", {}).get("group_size", -1))
+        if group_size > 0:
+            return group_size
+    return 128
+
+
+def _resolve_qwen_runtime_group_size(metadata: NunchakuQwenCheckpointMetadata) -> int:
+    group_size = _resolve_quant_group_size(metadata)
+    if group_size <= 0:
+        raise ValueError(f"Invalid Qwen runtime group size: {group_size}")
+    return group_size
+
+
+# ---------------------------------------------------------------------------
+# Tensor transfer helpers (unchanged)
+# ---------------------------------------------------------------------------
+
+def _maybe_pin_tensor(tensor: torch.Tensor, *, enabled: bool) -> torch.Tensor:
+    if not enabled or tensor.device.type != "cpu" or tensor.numel() == 0:
+        return tensor
+    try:
+        return tensor if tensor.is_pinned() else tensor.pin_memory()
+    except Exception:
+        return tensor
+
+
+def _move_tensor_to_device(tensor: torch.Tensor, *, device: torch.device | None, pin_memory: bool) -> torch.Tensor:
+    if device is None or tensor.device == device:
+        return tensor
+    tensor = _maybe_pin_tensor(tensor, enabled=pin_memory and device.type == "cuda")
+    non_blocking = bool(pin_memory and tensor.device.type == "cpu" and device.type == "cuda")
+    return tensor.to(device=device, non_blocking=non_blocking)
+
+
+def _move_and_cast_loaded_tensor(
+    tensor: torch.Tensor,
+    *,
+    device: str | torch.device | None,
+    dtype: torch.dtype | None = None,
+    pin_memory: bool = False,
+) -> torch.Tensor:
+    target_device = normalize_device(device) if device is not None else None
+    if target_device is not None and tensor.device != target_device:
+        tensor = _move_tensor_to_device(tensor, device=target_device, pin_memory=pin_memory)
+    if dtype is not None and tensor.is_floating_point() and tensor.dtype != dtype:
+        tensor = tensor.to(dtype=dtype)
+    return tensor
+
+
+def _iter_module_tensor_owners(
+    module: nn.Module,
+) -> tp.Iterator[tuple[nn.Module, str, str, torch.Tensor | nn.Parameter]]:
+    for submodule in module.modules():
+        for name, param in list(submodule.named_parameters(recurse=False)):
+            yield submodule, "_parameters", name, param
+        for name, buffer in list(submodule.named_buffers(recurse=False)):
+            if buffer is None:
+                continue
+            yield submodule, "_buffers", name, buffer
+
+
+def _replace_child_module(root: nn.Module, module_name: str, new_module: nn.Module) -> None:
+    parent_name, child_name = module_name.rsplit(".", 1)
+    parent = root.get_submodule(parent_name)
+    setattr(parent, child_name, new_module)
+
+
+def patch_qwen_runtime_linears(
+    module: nn.Module,
+    *,
+    metadata: NunchakuQwenCheckpointMetadata,
+    quantized_prefixes: set[str],
+    linear_dtype: torch.dtype | None = None,
+) -> None:
+    group_size = _resolve_qwen_runtime_group_size(metadata)
+    if not quantized_prefixes:
+        return
+    named_modules = dict(module.named_modules())
+    missing: list[str] = []
+    for module_name in sorted(quantized_prefixes):
+        target = named_modules.get(module_name)
+        if target is None:
+            missing.append(module_name)
+            continue
+        if not isinstance(target, nn.Linear):
+            raise TypeError(f"Expected `{module_name}` to be nn.Linear, got {type(target)}")
+        if linear_dtype is not None and target.weight.dtype != linear_dtype:
+            target.weight.data = target.weight.data.to(dtype=linear_dtype)
+        qmodule = W4Linear.from_linear(target, group_size=group_size, init_only=True)
+        _replace_child_module(module, module_name, qmodule)
+    if missing:
+        raise RuntimeError(
+            "Checkpoint expects quantized Qwen linears that were not found in the runtime model: "
+            f"{missing[:20]}"
+        )
+
+
+def materialize_meta_module_tensors(module: nn.Module, *, device: str | torch.device) -> None:
+    target_device = normalize_device(device)
+    for owner, store_name, name, tensor in _iter_module_tensor_owners(module):
+        if tensor.device.type != "meta":
+            continue
+        if store_name == "_parameters":
+            raise RuntimeError(
+                f"Unexpected meta parameter `{name}` on {type(owner).__name__}; "
+                "all parameters should come from the checkpoint."
+            )
+        replacement = _materialize_qwen_rotary_buffer(owner, name=name, device=target_device)
+        if replacement is None:
+            raise RuntimeError(
+                f"Unexpected meta buffer `{name}` on {type(owner).__name__}; "
+                "please add an explicit materialization rule instead of zero-initializing it."
+            )
+        if replacement.dtype != tensor.dtype:
+            replacement = replacement.to(dtype=tensor.dtype)
+        if tuple(replacement.shape) != tuple(tensor.shape):
+            raise RuntimeError(
+                f"Materialized buffer `{name}` on {type(owner).__name__} with shape {tuple(replacement.shape)}, "
+                f"expected {tuple(tensor.shape)}."
+            )
+        else:
+            owner._buffers[name] = replacement
+
+
+def load_qwen_runtime_state_dict(
+    handle: safetensors.safe_open,
+    *,
+    torch_dtype: torch.dtype,
+    output_device: str | torch.device | None = None,
+    pin_memory: bool = False,
+) -> dict[str, torch.Tensor]:
+    state_dict: dict[str, torch.Tensor] = {}
+    for key in handle.keys():
+        tensor = handle.get_tensor(key)
+        state_dict[key] = _move_and_cast_loaded_tensor(
+            tensor,
+            device=output_device,
+            dtype=torch_dtype if tensor.is_floating_point() else None,
+            pin_memory=pin_memory,
+        )
+    return state_dict
+
+
+def restore_qwen_runtime_model_tensors(
+    handle: safetensors.safe_open,
+    *,
+    model: nn.Module,
+    torch_dtype: torch.dtype,
+    output_device: str | torch.device | None = None,
+    pin_memory: bool = False,
+) -> tuple[list[str], list[str]]:
+    state_dict = load_qwen_runtime_state_dict(
+        handle,
+        torch_dtype=torch_dtype,
+        output_device=output_device,
+        pin_memory=pin_memory,
+    )
+    missing, unexpected = model.load_state_dict(state_dict, strict=False, assign=True)
+    materialize_meta_module_tensors(model, device=output_device or "cpu")
+    return missing, unexpected

--- a/nunchaku/models/text_encoders/qwen_encoder.py
+++ b/nunchaku/models/text_encoders/qwen_encoder.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import safetensors
+
+from .qwen_common import load_qwen_checkpoint_metadata, resolve_checkpoint_path
+from .qwen2_vl_edit_encoder import NunchakuQwen2VLEditEncoderModel
+from .qwen2_vl_text_encoder import NunchakuQwen2VLTextEncoderModel
+
+try:
+    from .qwen3_text_encoder import NunchakuQwen3TextEncoderModel
+except ImportError:  # pragma: no cover - optional on older transformers versions
+    NunchakuQwen3TextEncoderModel = None  # type: ignore[assignment]
+
+__all__ = ["NunchakuQwenEncoderModel"]
+
+
+class NunchakuQwenEncoderModel:
+    """Dispatch to the appropriate Qwen encoder runtime from one stable entry point."""
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path: str | Path, **kwargs):
+        ckpt = resolve_checkpoint_path(pretrained_model_name_or_path)
+        with safetensors.safe_open(str(ckpt), framework="pt", device="cpu") as handle:
+            metadata = load_qwen_checkpoint_metadata(handle)
+            raw_metadata = dict(handle.metadata() or {})
+        usage = metadata.text_encoder_usage.strip().lower()
+        model_type = str(raw_metadata.get("model_type", "")).strip().lower()
+        runtime_class = str(raw_metadata.get("runtime_class", "")).strip()
+        if usage == "qwenimage_edit_multimodal" or model_type == "qwen2_vl_edit_encoder":
+            return NunchakuQwen2VLEditEncoderModel.from_pretrained(ckpt, **kwargs)
+        if usage == "qwen3_text_only" or model_type == "qwen3_text" or runtime_class == "NunchakuQwen3TextEncoderModel":
+            if NunchakuQwen3TextEncoderModel is None:
+                raise ImportError(
+                    "Qwen3 runtime is not available in the installed environment. "
+                    "Please upgrade transformers to a version that provides `Qwen3Model`."
+                )
+            return NunchakuQwen3TextEncoderModel.from_pretrained(ckpt, **kwargs)
+        return NunchakuQwen2VLTextEncoderModel.from_pretrained(ckpt, **kwargs)

--- a/nunchaku/torch_transfer_utils.py
+++ b/nunchaku/torch_transfer_utils.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+import os
+import platform
+from collections.abc import Callable, Sequence
+from typing import Any, Literal
+
+import torch
+from torch import nn
+
+
+DEFAULT_PIPELINE_COMPONENT_ATTRS: tuple[str, ...] = ("text_encoder", "text_encoder_2", "vae", "unet", "transformer")
+_PRETOUCHED_SIGNATURE_ATTR = "_nunchaku_pretouched_cpu_signature"
+_PIPELINE_PRETOUCH_DECISIONS_ATTR = "_nunchaku_pretouch_auto_decisions"
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+_FALSE_VALUES = {"0", "false", "no", "off"}
+_CpuTensorSignature = tuple[tuple[str, str, tuple[int, ...], str, int], ...]
+
+
+def _env_flag(name: str) -> str | None:
+    value = os.environ.get(name)
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    return normalized or None
+
+
+def normalize_device(device: str | torch.device) -> torch.device:
+    return device if isinstance(device, torch.device) else torch.device(device)
+
+
+def _resolve_default_cuda_device() -> torch.device | None:
+    if not torch.cuda.is_available():
+        return None
+    try:
+        return torch.device(f"cuda:{torch.cuda.current_device()}")
+    except Exception:
+        return torch.device("cuda")
+
+
+def _parse_bool_or_auto(value: bool | str, *, name: str) -> bool | Literal["auto"]:
+    if isinstance(value, bool):
+        return value
+
+    normalized = value.strip().lower()
+    if normalized == "auto":
+        return "auto"
+    if normalized in _TRUE_VALUES:
+        return True
+    if normalized in _FALSE_VALUES:
+        return False
+    raise ValueError(f"Unsupported {name}={value!r}. Expected a boolean value or 'auto'.")
+
+
+def _matches_default_h2d_staging_platform(device: torch.device) -> bool:
+    if device.type != "cuda" or not torch.cuda.is_available():
+        return False
+
+    if platform.machine().lower() != "aarch64":
+        return False
+
+    index = 0 if device.index is None else device.index
+    try:
+        if index < 0 or index >= torch.cuda.device_count():
+            return False
+        capability = torch.cuda.get_device_capability(index)
+    except Exception:
+        return False
+
+    return capability[0] == 12
+
+
+def _resolve_page_size() -> int:
+    try:
+        return int(os.sysconf("SC_PAGE_SIZE"))
+    except (AttributeError, ValueError, OSError):
+        return 4096
+
+
+def _scan_module_cpu_tensors(module: nn.Module) -> tuple[list[torch.Tensor], _CpuTensorSignature]:
+    tensors: list[torch.Tensor] = []
+    signature: list[tuple[str, str, tuple[int, ...], str, int]] = []
+    for submodule in module.modules():
+        for name, tensor in list(submodule.named_parameters(recurse=False)) + list(submodule.named_buffers(recurse=False)):
+            if tensor.device.type != "cpu" or tensor.numel() == 0:
+                continue
+            tensors.append(tensor)
+            signature.append((type(tensor).__name__, name, tuple(tensor.shape), str(tensor.dtype), tensor.data_ptr()))
+    return tensors, tuple(signature)
+
+
+def _pretouch_tensor(tensor: torch.Tensor, *, page_size: int) -> None:
+    storage = tensor.untyped_storage()
+    storage_size = len(storage)
+    if storage_size == 0:
+        return
+
+    checksum = 0
+    for offset in range(0, storage_size, page_size):
+        checksum += int(storage[offset])
+    checksum += int(storage[storage_size - 1])
+    _ = checksum
+
+
+def _pretouch_module_cpu_tensors(module: nn.Module) -> tuple[int, bool]:
+    tensors, signature = _scan_module_cpu_tensors(module)
+    if not signature:
+        return 0, False
+
+    marker = signature
+    if getattr(module, _PRETOUCHED_SIGNATURE_ATTR, None) == marker:
+        return 0, False
+
+    page_size = _resolve_page_size()
+    with torch.no_grad():
+        for tensor in tensors:
+            _pretouch_tensor(tensor, page_size=page_size)
+
+    setattr(module, _PRETOUCHED_SIGNATURE_ATTR, marker)
+    return len(tensors), True
+
+
+def _need_pretouch_static(device: torch.device) -> bool:
+    override = _env_flag("NUNCHAKU_PRETOUCH_CPU_TENSORS")
+    if override is None:
+        override = _env_flag("NUNCHAKU_PRETOUCH_PIPELINE_CPU_TENSORS")
+    if override in _TRUE_VALUES:
+        return True
+    if override in _FALSE_VALUES:
+        return False
+
+    return _matches_default_h2d_staging_platform(device)
+
+
+def _need_pin_memory_static(device: torch.device) -> bool:
+    override = _env_flag("NUNCHAKU_PIN_MEMORY")
+    if override in _TRUE_VALUES:
+        return True
+    if override in _FALSE_VALUES:
+        return False
+    return _matches_default_h2d_staging_platform(device)
+
+
+def resolve_pin_memory(pin_memory: bool | str, device: str | torch.device) -> bool:
+    device = normalize_device(device)
+    if device.type != "cuda":
+        return False
+
+    pin_memory = _parse_bool_or_auto(pin_memory, name="pin_memory")
+    if pin_memory == "auto":
+        return _need_pin_memory_static(device)
+    return pin_memory
+
+
+def pin_state_dict(sd: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for key, value in sd.items():
+        if isinstance(value, torch.Tensor) and value.device.type == "cpu" and value.numel() > 0:
+            try:
+                out[key] = value if value.is_pinned() else value.pin_memory()
+            except Exception:
+                out[key] = value
+        else:
+            out[key] = value
+    return out
+
+
+def resolve_pretouch_cpu_tensors(
+    pretouch: bool | str,
+    pipe: Any,
+    device: str | torch.device,
+    *,
+    context: str = "pipeline_to_cuda",
+    component_attrs: Sequence[str] = DEFAULT_PIPELINE_COMPONENT_ATTRS,
+) -> bool:
+    device = normalize_device(device)
+    if device.type != "cuda":
+        return False
+
+    pretouch = _parse_bool_or_auto(pretouch, name="pretouch")
+    if pretouch != "auto":
+        return pretouch
+
+    decisions = getattr(pipe, _PIPELINE_PRETOUCH_DECISIONS_ATTR, None)
+    if not isinstance(decisions, dict):
+        decisions = {}
+        setattr(pipe, _PIPELINE_PRETOUCH_DECISIONS_ATTR, decisions)
+
+    key = (
+        device.type,
+        device.index,
+        context,
+        tuple(component_attrs),
+        _env_flag("NUNCHAKU_PRETOUCH_CPU_TENSORS"),
+        _env_flag("NUNCHAKU_PRETOUCH_PIPELINE_CPU_TENSORS"),
+    )
+    if key in decisions:
+        return decisions[key]
+
+    decision = _need_pretouch_static(device)
+    decisions[key] = decision
+    return decision
+
+
+def should_pretouch(device: str | torch.device | None = None) -> bool:
+    """
+    Return whether Nunchaku's default policy recommends pretouching CPU tensors.
+
+    This is a public recommendation API. It does not trigger pretouch by
+    itself; callers should use it to decide whether to invoke
+    :func:`pretouch_pipeline_cpu_tensors` explicitly before ``pipe.to("cuda")``
+    or before a CPU offload flow that will move model weights back to CUDA.
+
+    When ``device`` is omitted, the current CUDA device is used if CUDA is
+    available. This keeps the common single-GPU case concise while still
+    allowing explicit multi-GPU selection.
+
+    The default policy enables pretouch on ``aarch64`` systems with
+    Blackwell-class CUDA GPUs (compute capability major version 12).
+    Environment overrides via ``NUNCHAKU_PRETOUCH_CPU_TENSORS`` or
+    ``NUNCHAKU_PRETOUCH_PIPELINE_CPU_TENSORS`` take precedence.
+    """
+    if device is None:
+        resolved_device = _resolve_default_cuda_device()
+        if resolved_device is None:
+            return False
+    else:
+        resolved_device = normalize_device(device)
+    return _need_pretouch_static(resolved_device)
+
+
+def pretouch_pipeline_cpu_tensors(
+    pipe: Any,
+    component_attrs: Sequence[str] = DEFAULT_PIPELINE_COMPONENT_ATTRS,
+    on_component: Callable[[str], None] | None = None,
+) -> bool:
+    """
+    Pretouch common pipeline components on CPU before CUDA transfer.
+
+    This is the main explicit execution API. It walks the known CPU-side
+    pipeline components, touches one byte per memory page for each tensor,
+    and skips components whose CPU tensor signature has not changed since the
+    previous pretouch call.
+
+    Returns ``True`` when at least one component was newly pretouched and
+    ``False`` when nothing needed touching.
+    """
+    touched_any = False
+    for attr in component_attrs:
+        if not hasattr(pipe, attr):
+            continue
+        module = getattr(pipe, attr)
+        if module is None or not isinstance(module, nn.Module):
+            continue
+        touched, did_pretouch = _pretouch_module_cpu_tensors(module)
+        if on_component is not None and did_pretouch:
+            on_component(attr)
+        touched_any = touched > 0 or touched_any
+    return touched_any
+
+
+def maybe_pretouch_pipeline_cpu_tensors(
+    pipe: Any,
+    device: str | torch.device,
+    *,
+    pretouch: bool | str = "auto",
+    context: str = "pipeline_to_cuda",
+    component_attrs: Sequence[str] = DEFAULT_PIPELINE_COMPONENT_ATTRS,
+    on_component: Callable[[str], None] | None = None,
+) -> bool:
+    """
+    Conditionally pretouch pipeline CPU tensors using an explicit policy.
+
+    This helper is still explicit: callers opt in by invoking it. When
+    ``pretouch="auto"``, the decision follows :func:`should_pretouch` and the
+    environment-variable overrides. When ``pretouch`` is a boolean, that value
+    is used directly.
+    """
+    if not resolve_pretouch_cpu_tensors(
+        pretouch,
+        pipe,
+        device,
+        context=context,
+        component_attrs=component_attrs,
+    ):
+        return False
+    return pretouch_pipeline_cpu_tensors(
+        pipe,
+        component_attrs=component_attrs,
+        on_component=on_component,
+    )


### PR DESCRIPTION
#### Summary
This PR adds Nunchaku runtimes for Qwen-family text encoders and exposes them via the public `nunchaku` API. It includes:
- A **stable entry point** (`NunchakuQwenEncoderModel`) that **auto-dispatches** to the correct runtime based on exported `.safetensors` metadata.
- Dedicated runtimes for:
  - **Qwen2.5-VL text-only encoder** (`NunchakuQwen2VLTextEncoderModel`)
  - **Qwen2.5-VL multimodal edit encoder** (`NunchakuQwen2VLEditEncoderModel`)
  - **Qwen3 text-only encoder** (`NunchakuQwen3TextEncoderModel`, optional depending on `transformers` version)

#### Key changes
- **Public exports**
  - Export Qwen encoder models from `nunchaku/__init__.py` and `nunchaku/models/__init__.py`
  - Add `nunchaku/models/text_encoders/__init__.py` exports
- **New Qwen encoder runtimes**
  - `nunchaku/models/text_encoders/qwen_encoder.py`: dispatcher `from_pretrained()` selecting the correct runtime via checkpoint metadata (`text_encoder_usage`, `model_type`, `runtime_class`)
  - `nunchaku/models/text_encoders/qwen2_vl_text_encoder.py`: Qwen2.5-VL **text-only** runtime (rejects multimodal args)
  - `nunchaku/models/text_encoders/qwen2_vl_edit_encoder.py`: Qwen2.5-VL **edit/multimodal** runtime
  - `nunchaku/models/text_encoders/qwen3_text_encoder.py`: Qwen3 **text-only** runtime 
  - `nunchaku/models/text_encoders/qwen_common.py`: unified base class, checkpoint metadata parsing, config building, quantized linear patching, and rotary buffer materializers
- **Transfer utilities**
  - `nunchaku/torch_transfer_utils.py`: device normalization + pin-memory policy + optional “pretouch” helpers for CPU→CUDA staging

#### Files changed
- **Updated (overwritten)**
  - `nunchaku/__init__.py`
  - `nunchaku/models/__init__.py`
  - `nunchaku/models/text_encoders/__init__.py`
- **Added**
  - `nunchaku/models/text_encoders/qwen_encoder.py`
  - `nunchaku/models/text_encoders/qwen_common.py`
  - `nunchaku/models/text_encoders/qwen2_vl_text_encoder.py`
  - `nunchaku/models/text_encoders/qwen2_vl_edit_encoder.py`
  - `nunchaku/models/text_encoders/qwen3_text_encoder.py`
  - `nunchaku/torch_transfer_utils.py`

#### Test plan
- [ ] Import smoke test:
  - `python -c "from nunchaku import NunchakuQwenEncoderModel, NunchakuQwen2VLTextEncoderModel, NunchakuQwen2VLEditEncoderModel; print('ok')"`
- [ ] Dispatcher path:
  - `python -c "from nunchaku import NunchakuQwenEncoderModel; m=NunchakuQwenEncoderModel.from_pretrained('path/to/qwen_encoder.safetensors', device='cpu'); print(type(m))"`
- [ ] (Optional) Qwen3 availability:
  - If `transformers` provides `Qwen3Model`, load a Qwen3 exported checkpoint; otherwise confirm it raises a clear ImportError message.

Model download link:

https://huggingface.co/tonera/Qwen2.5vl-Nunchaku
https://huggingface.co/tonera/Qwen3-text-Nunchaku

